### PR TITLE
Add admin user delete feature

### DIFF
--- a/client/src/__test__/UserSearchPage.test.js
+++ b/client/src/__test__/UserSearchPage.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+jest.mock('../axiosConfig', () => ({ get: jest.fn(), delete: jest.fn() }));
+import AdminUserSearchPage from '../components/AdminUserSearchPage';
+
+it('renders AdminUserSearchPage without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<AdminUserSearchPage />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -15,6 +15,10 @@ import RegisterForm from './RegisterForm';
 import ResetPasswordPage from './ResetPasswordPage';
 import ChangePasswordPage from './ChangePasswordPage';
 import ConfirmPage from './ConfirmPage';
+import AdminCleanupExpiredTokens from '../menus/Admin/AdminCleanupExpiredTokens';
+import AdminUserSearchPage from '../menus/Admin/AdminUserSearchPage';
+import RequireAuth from './RequireAuth';
+import RequireAdmin from './RequireAdmin';
 
 export default function App() {
 //  console.log('App');
@@ -128,6 +132,8 @@ export default function App() {
             <Route path="/login" element={<LoginForm />} />
             <Route path="/register" element={<RegisterForm />} />
             <Route path="/confirm" element={<ConfirmPage />} />
+            <Route path="/admin/cleanup-expired-tokens" element={<RequireAuth><RequireAdmin><AdminCleanupExpiredTokens /></RequireAdmin></RequireAuth>} />
+            <Route path="/admin/user-search" element={<RequireAuth><RequireAdmin><AdminUserSearchPage /></RequireAdmin></RequireAuth>} />
             <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route path="/change-password" element={<ChangePasswordPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/client/src/components/MainPage.jsx
+++ b/client/src/components/MainPage.jsx
@@ -40,7 +40,7 @@ import HelpIndex from '../menus/Help/HelpIndex';
 import HelpDemo from '../menus/Help/HelpDemo';
 import HelpTutorial from '../menus/Help/HelpTutorial';
 import HelpAbout from '../menus/Help/HelpAbout';
-import AdminCleanUpExpiredTokens from '../menus/Admin/AdminCleanUpExpiredTokens';
+import { Link } from 'react-router-dom';
 import SearchDocs from './SearchDocs';
 import config from '../config';
 import ResultTable from './ResultTable';
@@ -184,7 +184,8 @@ export default function MainPage() {
             </NavDropdown>
             <RequireAdmin>
               <NavDropdown title="Admin">
-                <AdminCleanUpExpiredTokens />
+                <NavDropdown.Item as={Link} to="/admin/cleanup-expired-tokens">Cleanup Expired Tokens</NavDropdown.Item>
+                <NavDropdown.Item as={Link} to="/admin/user-search">User Search</NavDropdown.Item>
               </NavDropdown>
             </RequireAdmin>
           </Nav>

--- a/client/src/menus/Admin/AdminCleanupExpiredTokens.js
+++ b/client/src/menus/Admin/AdminCleanupExpiredTokens.js
@@ -6,17 +6,17 @@ import { logUsage } from '../../logUsage';
 import { changeResultTerminationCondition } from '../../store/actions';
 import axios from '../../axiosConfig';
 
-export default function AdminCleanUpExpiredTokens() {
-//  console.log('AdminCleanUpExpiredTokens');
+export default function AdminCleanupExpiredTokens() {
+//  console.log('AdminCleanupExpiredTokens');
   const dispatch = useDispatch();
 //  const navigate = useNavigate();
 
   const toggle = async () => {
-//    console.log('AdminCleanUpExpiredTokens.toggle');
+//    console.log('AdminCleanupExpiredTokens.toggle');
     try {
       const res = await axios.delete('/api/v1/cleanup-expired-tokens');
-//      console.log('AdminCleanUpExpiredTokens.toggle','res=',res);
-      logUsage('event', 'AdminCleanUpExpiredTokens', { event_label: '' });
+//      console.log('AdminCleanupExpiredTokens.toggle','res=',res);
+      logUsage('event', 'AdminCleanupExpiredTokens', { event_label: '' });
       dispatch(changeResultTerminationCondition(res.data.error.message));
 //      navigate('/');
     } catch (err) {

--- a/client/src/menus/Admin/AdminUserSearchPage.js
+++ b/client/src/menus/Admin/AdminUserSearchPage.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import axios from '../../axiosConfig';
+import { Container, Row, Col, Form, Button, Table } from 'react-bootstrap';
+import MessageAlert from '../../components/MessageAlert';
+import { logUsage } from '../../logUsage';
+import { useAuth } from '../../components/AuthProvider';
+
+export default function AdminUserSearchPage() {
+  const [email, setEmail] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [role, setRole] = useState('');
+  const [status, setStatus] = useState('');
+  const [results, setResults] = useState([]);
+  const [error, setError] = useState(null);
+  const { authState } = useAuth();
+
+  const handleDelete = async (id) => {
+    setError(null);
+    try {
+      await axios.delete(`/api/v1/users/${id}`, {
+        headers: {
+          Authorization: 'Bearer ' + authState.token
+        },
+      });
+      setError(res.data.error);
+      setResults(results.filter((u) => u.id !== id));
+      logUsage('event', 'AdminUserSearchPage', { event_label: 'delete id:' + id });
+    } catch (err) {
+      setError(err.response?.data?.error || err.message);
+    }
+  };
+
+  const handleSearch = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await axios.get('/api/v1/users', { 
+        headers: {
+          Authorization: 'Bearer ' + authState.token
+        },
+        params: { email, firstName, lastName, role, status }
+      });
+      setError(res.data.error);
+      setResults(res.data);
+      logUsage('event', 'AdminUserSearchPage', { event_label: 'search email:' + email + ' firstName:' + firstName + ' lastName:' + lastName+ ' role:' + role+ ' status:' + status });
+    } catch (err) {
+      setError(err.response?.data?.error || err.message);
+      setResults([]);
+    }
+  };
+
+  return (
+    <Container className="pt-5">
+      <Row>
+        <Col lg="12">
+          <h1>User Search</h1>
+          <form onSubmit={handleSearch} className="mb-3">
+            <Form.Group controlId="searchEmail">
+              <Form.Label>Email</Form.Label>
+              <Form.Control value={email} onChange={(e) => setEmail(e.target.value)} />
+            </Form.Group>
+            <Form.Group controlId="searchFirstName">
+              <Form.Label>First Name</Form.Label>
+              <Form.Control value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </Form.Group>
+            <Form.Group controlId="searchLastName">
+              <Form.Label>LastName</Form.Label>
+              <Form.Control value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </Form.Group>
+            <Form.Group controlId="searchRole">
+              <Form.Label>Role</Form.Label>
+              <Form.Select aria-label="Role Search Input" onChange={(e) => setRole(e.target.value)} >
+                <option value=""></option>
+                <option value="admin">admin</option>
+                <option value="user">user</option>
+              </Form.Select>
+            </Form.Group>
+            <Form.Group controlId="searchStatus">
+              <Form.Label>Status</Form.Label>
+              <Form.Select aria-label="Status Search Input" onChange={(e) => setStatus(e.target.value)} >
+                <option value=""></option>
+                <option value="active">active</option>
+                <option value="inactive">inactive</option>
+              </Form.Select>
+            </Form.Group>
+            <Button className="mt-2" type="reset" onClick={(e) => {setEmail('');setFirstName('');setLastName('');}}>Reset</Button>&nbsp;
+            <Button className="mt-2" type="submit">Search</Button>
+          </form>
+          <MessageAlert error={error} />
+          <p>Found {results.length} Users</p>
+          {results.length > 0 && (
+            <Table bordered hover size="sm" className="mt-3">
+              <thead>
+                <tr>
+                  <th>Email</th>
+                  <th>First Name</th>
+                  <th>Last Name</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                  <th>Created</th>
+                  <th>Last Login</th>
+                  <th>Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((u) => (
+                  <tr key={u.id}>
+                    <td>{u.email}</td>
+                    <td>{u.first_name}</td>
+                    <td>{u.last_name}</td>
+                    <td>{u.role}</td>
+                    <td>{u.status}</td>
+                    <td>{u.created_at}</td>
+                    <td>{u.last_login_at}</td>
+                    <td>
+                      <Button variant="link" onClick={() => handleDelete(u.id)}>
+                        <i className="fas fa-trash text-danger"></i>
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+        </Col>
+      </Row>
+    </Container>
+  );
+}

--- a/data/create.sql
+++ b/data/create.sql
@@ -31,11 +31,11 @@ CREATE TABLE `design` (
   `id` int NOT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `user` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `type` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `name` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `value` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+  `user` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `type` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -50,7 +50,7 @@ CREATE TABLE `token` (
   `type` varchar(50) DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `expires_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -64,7 +64,7 @@ CREATE TABLE `usage_log` (
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `ip_address` varchar(64) NOT NULL,
   `note` longtext DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -83,7 +83,7 @@ CREATE TABLE `user` (
   `status` varchar(50) DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `last_login_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --
 -- Indexes for dumped tables

--- a/scripts/import-okta-csv.js
+++ b/scripts/import-okta-csv.js
@@ -25,6 +25,8 @@ async function main(filePath) {
     process.exit(1);
   }
 
+  console.log('user=',process.env.MYSQL_USER,'password=','<HIDDEN>','host=',process.env.MYSQL_HOST,'host=',process.env.MYSQL_PORT,'host=',process.env.MYSQL_DATABASE);
+
   let insertedCount = 0;
   let updatedCount = 0;
   let skippedCount = 0;

--- a/test/api_misc_endpoints_test.js
+++ b/test/api_misc_endpoints_test.js
@@ -1,0 +1,185 @@
+require('dotenv').config();
+
+// Load testTestDesign into the design table with name='test' and type='Test-Design'
+// Model this after the design/model used by the client, but without content
+const testTestDesign = {
+    "type": "Test-Design",
+    "version": "0.0"
+};
+// Same name, but different type
+const testTestDesign2 = {
+    "type": "Test-Design2",
+    "version": "0.2"
+};
+// Different name, but same type
+const test2TestDesign = {
+    "type": "Test-Design",
+    "version": "2.0"
+};
+
+process.env.NODE_ENV = 'test';
+
+const mysql = require('mysql');
+
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+let server = require('../server');
+let should = chai.should();
+
+chai.use(chaiHttp);
+
+// ============================================================================
+
+describe('Misc API endpoints and empty DB', () => {
+
+      beforeEach((done) => { // Before each test we empty the database
+          var connection = mysql.createConnection(process.env.JAWSDB_TEST_URL);
+          connection.connect();
+          var stmt = 'DELETE FROM user WHERE 1'; // Empty test user table
+  //        console.log('TEST: stmt='+stmt);
+          connection.query(stmt, function(err, rows, fields) {
+  //            console.log('TEST: After DELETE FROM user err=', err, ' rows=', rows);
+              if (err) throw err;
+              stmt = 'DELETE FROM token WHERE 1'; // Empty test token table
+  //            console.log('TEST: stmt='+stmt);
+              connection.query(stmt, function(err, rows, fields) {
+  //                console.log('TEST: After DELETE FROM token err=', err, ' rows=', rows);
+                  if (err) throw err;
+                  done();
+                  connection.end();
+              });
+          });
+      });
+
+    describe('GET /api/v1/db_size without Authorization', () => {
+        it('it should GET with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .get('/api/v1/db_size')
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('GET /api/v1/search', () => {
+        it('it should GET with 200 OK', (done) => {
+            chai.request(server)
+                .get('/api/v1/search')
+                .query({ terms: 'spring' })
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    res.body.should.be.a('array');
+                    done(err);
+                });
+        });
+    });
+
+    describe('GET /api/v1/me without session', () => {
+        it('it should GET with 200 OK unauthenticated', (done) => {
+            chai.request(server)
+                .get('/api/v1/me')
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    res.body.should.be.a('object');
+                    res.body.should.have.nested.property('authState.isAuthenticated', false);
+                    done(err);
+                });
+        });
+    });
+
+    describe('POST /api/v1/register with short password', () => {
+        it('it should fail POST with 400 BAD REQUEST', (done) => {
+            chai.request(server)
+                .post('/api/v1/register')
+                .send({ email: 'test@example.com', password: 'short', first_name: 'F', last_name: 'L' })
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    done(err);
+                });
+        });
+    });
+
+    describe('POST /api/v1/logout', () => {
+        it('it should POST with 200 OK', (done) => {
+            chai.request(server)
+                .post('/api/v1/logout')
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    done(err);
+                });
+        });
+    });
+
+    describe('GET /api/v1/confirm with invalid token', () => {
+        it('it should fail GET with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .get('/api/v1/confirm')
+                .query({ token: 'invalid-token' })
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('GET /api/v1/has-password with unknown email', () => {
+        it('it should fail GET with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .get('/api/v1/has-password')
+                .query({ email: 'unknown@example.com' })
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('POST /api/v1/login with invalid credentials', () => {
+        it('it should fail POST with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .post('/api/v1/login')
+                .send({ email: 'nouser@example.com', password: 'Badpass1' })
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('POST /api/v1/reset-password with unknown email', () => {
+        it('it should fail POST with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .post('/api/v1/reset-password')
+                .send({ email: 'nouser@example.com' })
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('PATCH /api/v1/change-password with invalid token', () => {
+        it('it should fail PATCH with 401 UNAUTHORIZED', (done) => {
+            chai.request(server)
+                .patch('/api/v1/change-password')
+                .send({ email: 'nouser@example.com', token: 'bad', password: 'Valid123' })
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    done(err);
+                });
+        });
+    });
+
+    describe('DELETE /api/v1/cleanup-expired-tokens', () => {
+        it('it should DELETE with 200 OK', (done) => {
+            chai.request(server)
+                .delete('/api/v1/cleanup-expired-tokens')
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    done(err);
+                });
+        });
+    });
+
+});

--- a/test/api_users_search_test.js
+++ b/test/api_users_search_test.js
@@ -1,0 +1,68 @@
+require('dotenv').config();
+
+process.env.NODE_ENV = 'test';
+
+const mysql = require('mysql');
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+let server = require('../server');
+let should = chai.should();
+let userId;
+
+chai.use(chaiHttp);
+
+describe('Admin User Search', () => {
+  before((done) => {
+    var connection = mysql.createConnection(process.env.JAWSDB_TEST_URL);
+    connection.connect();
+    const stmt = "INSERT INTO user (email, first_name, last_name, role, token, status) VALUES ('search@example.com','First','Last','admin','ADMINTOKEN','active')";
+    connection.query(stmt, function(err, results) {
+      if (!err) userId = results.insertId;
+      connection.end();
+      done(err);
+    });
+  });
+
+  after((done) => {
+    var connection = mysql.createConnection(process.env.JAWSDB_TEST_URL);
+    connection.connect();
+    connection.query('DELETE FROM user WHERE id = ?', [userId], function(err) {
+      connection.end();
+      done(err);
+    });
+  });
+
+  it('should fail without auth', (done) => {
+    chai
+      .request(server)
+      .get('/api/v1/users')
+      .end((err, res) => {
+        res.should.have.status(401);
+        done(err);
+      });
+  });
+
+  it('should get user list by email', (done) => {
+    chai
+      .request(server)
+      .get('/api/v1/users?email=search@example.com')
+      .set('Authorization', 'Bearer ADMINTOKEN')
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('array');
+        res.body.length.should.be.eql(1);
+        done(err);
+      });
+  });
+
+  it('should delete user by id', (done) => {
+    chai
+      .request(server)
+      .delete(`/api/v1/users/${userId}`)
+      .set('Authorization', 'Bearer ADMINTOKEN')
+      .end((err, res) => {
+        res.should.have.status(200);
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- support admin delete user endpoint
- display delete icon on UserSearchPage
- handle delete click in UserSearchPage
- improve UserSearchPage tests
- cover user deletion API in tests

## Testing
- `npm test` *(fails: connect ENETUNREACH 52.202.225.103:3306 - Local (0.0.0.0:0))*
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c4333b0708330bdf479eeb5a7acfa