### PR TITLE
Add sorting to Admin user search table

### DIFF
--- a/client/src/menus/Admin/AdminUserSearchPage.js
+++ b/client/src/menus/Admin/AdminUserSearchPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import axios from '../../axiosConfig';
 import { Container, Row, Col, Form, Button, Table } from 'react-bootstrap';
 import MessageAlert from '../../components/MessageAlert';
@@ -13,6 +13,8 @@ export default function AdminUserSearchPage() {
   const [status, setStatus] = useState('');
   const [results, setResults] = useState([]);
   const [error, setError] = useState(null);
+  const [sortColumn, setSortColumn] = useState('');
+  const [sortDirection, setSortDirection] = useState('asc');
   const { authState } = useAuth();
 
   const handleDelete = async (id) => {
@@ -48,6 +50,41 @@ export default function AdminUserSearchPage() {
       setError(err.response?.data?.error || err.message);
       setResults([]);
     }
+  };
+
+  const handleSort = (column) => {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortColumn(column);
+      setSortDirection('asc');
+    }
+  };
+
+  const sortedResults = useMemo(() => {
+    const sorted = [...results];
+    if (sortColumn) {
+      sorted.sort((a, b) => {
+        const valA = a[sortColumn] || '';
+        const valB = b[sortColumn] || '';
+        if (valA < valB) return -1;
+        if (valA > valB) return 1;
+        return 0;
+      });
+      if (sortDirection === 'desc') {
+        sorted.reverse();
+      }
+    }
+    return sorted;
+  }, [results, sortColumn, sortDirection]);
+
+  const sortIcon = (column) => {
+    if (sortColumn !== column) return null;
+    return sortDirection === 'asc' ? (
+      <i className="fas fa-arrow-up ms-1"></i>
+    ) : (
+      <i className="fas fa-arrow-down ms-1"></i>
+    );
   };
 
   return (
@@ -93,18 +130,32 @@ export default function AdminUserSearchPage() {
             <Table bordered hover size="sm" className="mt-3">
               <thead>
                 <tr>
-                  <th>Email</th>
-                  <th>First Name</th>
-                  <th>Last Name</th>
-                  <th>Role</th>
-                  <th>Status</th>
-                  <th>Created</th>
-                  <th>Last Login</th>
+                  <th onClick={() => handleSort('email')} style={{ cursor: 'pointer' }}>
+                    Email{sortIcon('email')}
+                  </th>
+                  <th onClick={() => handleSort('first_name')} style={{ cursor: 'pointer' }}>
+                    First Name{sortIcon('first_name')}
+                  </th>
+                  <th onClick={() => handleSort('last_name')} style={{ cursor: 'pointer' }}>
+                    Last Name{sortIcon('last_name')}
+                  </th>
+                  <th onClick={() => handleSort('role')} style={{ cursor: 'pointer' }}>
+                    Role{sortIcon('role')}
+                  </th>
+                  <th onClick={() => handleSort('status')} style={{ cursor: 'pointer' }}>
+                    Status{sortIcon('status')}
+                  </th>
+                  <th onClick={() => handleSort('created_at')} style={{ cursor: 'pointer' }}>
+                    Created{sortIcon('created_at')}
+                  </th>
+                  <th onClick={() => handleSort('last_login_at')} style={{ cursor: 'pointer' }}>
+                    Last Login{sortIcon('last_login_at')}
+                  </th>
                   <th>Delete</th>
                 </tr>
               </thead>
               <tbody>
-                {results.map((u) => (
+                {sortedResults.map((u) => (
                   <tr key={u.id}>
                     <td>{u.email}</td>
                     <td>{u.first_name}</td>


### PR DESCRIPTION
## Summary
- allow admin users to sort search results by clicking on column headers
- show an up or down arrow on the selected column

## Testing
- `npm test` *(fails: connect ENETUNREACH 52.202.225.103:3306)*
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d20ba36848330b7a1f4679ed48113