### PR TITLE
Add admin user create/edit modal

### DIFF
--- a/client/src/menus/Admin/AdminUserModal.js
+++ b/client/src/menus/Admin/AdminUserModal.js
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from "react";
+import axios from "../../axiosConfig";
+import { Modal, Button, Form } from "react-bootstrap";
+import MessageAlert from "../../components/MessageAlert";
+import { useAuth } from "../../components/AuthProvider";
+import { logUsage } from "../../logUsage";
+
+export default function AdminUserModal({ show, onHide, user, onSaved }) {
+  const isEdit = !!user;
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [role, setRole] = useState("user");
+  const [status, setStatus] = useState("active");
+  const [error, setError] = useState(null);
+  const { authState } = useAuth();
+
+  useEffect(() => {
+    if (user) {
+      setEmail(user.email || "");
+      setFirstName(user.first_name || "");
+      setLastName(user.last_name || "");
+      setRole(user.role || "user");
+      setStatus(user.status || "active");
+    } else {
+      setEmail("");
+      setPassword("");
+      setFirstName("");
+      setLastName("");
+      setRole("user");
+      setStatus("active");
+    }
+  }, [user, show]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      if (isEdit) {
+        await axios.put(
+          `/api/v1/users/${user.id}`,
+          { email, first_name: firstName, last_name: lastName, role, status },
+          { headers: { Authorization: "Bearer " + authState.token } },
+        );
+      } else {
+        await axios.post(
+          "/api/v1/users",
+          {
+            email,
+            password,
+            first_name: firstName,
+            last_name: lastName,
+            role,
+            status,
+          },
+          { headers: { Authorization: "Bearer " + authState.token } },
+        );
+      }
+      logUsage("event", "AdminUserModal", {
+        event_label: isEdit ? "update" : "create",
+      });
+      onSaved();
+      onHide();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message);
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>{isEdit ? "Edit User" : "New User"}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <MessageAlert error={error} />
+        <Form onSubmit={handleSubmit}>
+          <Form.Group controlId="userEmail">
+            <Form.Label>Email</Form.Label>
+            <Form.Control
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </Form.Group>
+          {!isEdit && (
+            <Form.Group controlId="userPassword">
+              <Form.Label>Password</Form.Label>
+              <Form.Control
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </Form.Group>
+          )}
+          <Form.Group controlId="userFirstName">
+            <Form.Label>First Name</Form.Label>
+            <Form.Control
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </Form.Group>
+          <Form.Group controlId="userLastName">
+            <Form.Label>Last Name</Form.Label>
+            <Form.Control
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+          </Form.Group>
+          <Form.Group controlId="userRole">
+            <Form.Label>Role</Form.Label>
+            <Form.Select value={role} onChange={(e) => setRole(e.target.value)}>
+              <option value="admin">admin</option>
+              <option value="user">user</option>
+            </Form.Select>
+          </Form.Group>
+          <Form.Group controlId="userStatus">
+            <Form.Label>Status</Form.Label>
+            <Form.Select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value="active">active</option>
+              <option value="inactive">inactive</option>
+            </Form.Select>
+          </Form.Group>
+          <Button className="mt-2" type="submit">
+            Save
+          </Button>
+        </Form>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/client/src/menus/Admin/AdminUserSearchPage.js
+++ b/client/src/menus/Admin/AdminUserSearchPage.js
@@ -1,18 +1,21 @@
-import React, { useState } from 'react';
-import axios from '../../axiosConfig';
-import { Container, Row, Col, Form, Button, Table } from 'react-bootstrap';
-import MessageAlert from '../../components/MessageAlert';
-import { logUsage } from '../../logUsage';
-import { useAuth } from '../../components/AuthProvider';
+import React, { useState } from "react";
+import axios from "../../axiosConfig";
+import { Container, Row, Col, Form, Button, Table } from "react-bootstrap";
+import MessageAlert from "../../components/MessageAlert";
+import { logUsage } from "../../logUsage";
+import { useAuth } from "../../components/AuthProvider";
+import AdminUserModal from "./AdminUserModal";
 
 export default function AdminUserSearchPage() {
-  const [email, setEmail] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [role, setRole] = useState('');
-  const [status, setStatus] = useState('');
+  const [email, setEmail] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [role, setRole] = useState("");
+  const [status, setStatus] = useState("");
   const [results, setResults] = useState([]);
   const [error, setError] = useState(null);
+  const [modalShow, setModalShow] = useState(false);
+  const [editUser, setEditUser] = useState(null);
   const { authState } = useAuth();
 
   const handleDelete = async (id) => {
@@ -20,34 +23,62 @@ export default function AdminUserSearchPage() {
     try {
       const res = await axios.delete(`/api/v1/users/${id}`, {
         headers: {
-          Authorization: 'Bearer ' + authState.token
+          Authorization: "Bearer " + authState.token,
         },
       });
       setError(res.data.error);
       setResults(results.filter((u) => u.id !== id));
-      logUsage('event', 'AdminUserSearchPage', { event_label: 'delete id:' + id });
+      logUsage("event", "AdminUserSearchPage", {
+        event_label: "delete id:" + id,
+      });
     } catch (err) {
       setError(err.response?.data?.error || err.message);
     }
   };
 
   const handleSearch = async (e) => {
-    e.preventDefault();
+    if (e) e.preventDefault();
     setError(null);
     try {
-      const res = await axios.get('/api/v1/users', { 
+      const res = await axios.get("/api/v1/users", {
         headers: {
-          Authorization: 'Bearer ' + authState.token
+          Authorization: "Bearer " + authState.token,
         },
-        params: { email, firstName, lastName, role, status }
+        params: { email, firstName, lastName, role, status },
       });
       setError(res.data.error);
       setResults(res.data);
-      logUsage('event', 'AdminUserSearchPage', { event_label: 'search email:' + email + ' firstName:' + firstName + ' lastName:' + lastName+ ' role:' + role+ ' status:' + status });
+      logUsage("event", "AdminUserSearchPage", {
+        event_label:
+          "search email:" +
+          email +
+          " firstName:" +
+          firstName +
+          " lastName:" +
+          lastName +
+          " role:" +
+          role +
+          " status:" +
+          status,
+      });
     } catch (err) {
       setError(err.response?.data?.error || err.message);
       setResults([]);
     }
+  };
+
+  const handleNew = () => {
+    setEditUser(null);
+    setModalShow(true);
+  };
+
+  const handleEdit = (user) => {
+    setEditUser(user);
+    setModalShow(true);
+  };
+
+  const handleSaved = () => {
+    handleSearch();
   };
 
   return (
@@ -55,22 +86,37 @@ export default function AdminUserSearchPage() {
       <Row>
         <Col lg="12">
           <h1>User Search</h1>
+          <Button className="mb-3" onClick={handleNew}>
+            New User
+          </Button>
           <form onSubmit={handleSearch} className="mb-3">
             <Form.Group controlId="searchEmail">
               <Form.Label>Email</Form.Label>
-              <Form.Control value={email} onChange={(e) => setEmail(e.target.value)} />
+              <Form.Control
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
             </Form.Group>
             <Form.Group controlId="searchFirstName">
               <Form.Label>First Name</Form.Label>
-              <Form.Control value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+              <Form.Control
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
             </Form.Group>
             <Form.Group controlId="searchLastName">
               <Form.Label>LastName</Form.Label>
-              <Form.Control value={lastName} onChange={(e) => setLastName(e.target.value)} />
+              <Form.Control
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+              />
             </Form.Group>
             <Form.Group controlId="searchRole">
               <Form.Label>Role</Form.Label>
-              <Form.Select aria-label="Role Search Input" onChange={(e) => setRole(e.target.value)} >
+              <Form.Select
+                aria-label="Role Search Input"
+                onChange={(e) => setRole(e.target.value)}
+              >
                 <option value=""></option>
                 <option value="admin">admin</option>
                 <option value="user">user</option>
@@ -78,14 +124,32 @@ export default function AdminUserSearchPage() {
             </Form.Group>
             <Form.Group controlId="searchStatus">
               <Form.Label>Status</Form.Label>
-              <Form.Select aria-label="Status Search Input" onChange={(e) => setStatus(e.target.value)} >
+              <Form.Select
+                aria-label="Status Search Input"
+                onChange={(e) => setStatus(e.target.value)}
+              >
                 <option value=""></option>
                 <option value="active">active</option>
                 <option value="inactive">inactive</option>
               </Form.Select>
             </Form.Group>
-            <Button className="mt-2" type="reset" onClick={(e) => {setEmail('');setFirstName('');setLastName('');setRole('');setStatus('');}}>Reset</Button>&nbsp;
-            <Button className="mt-2" type="submit">Search</Button>
+            <Button
+              className="mt-2"
+              type="reset"
+              onClick={(e) => {
+                setEmail("");
+                setFirstName("");
+                setLastName("");
+                setRole("");
+                setStatus("");
+              }}
+            >
+              Reset
+            </Button>
+            &nbsp;
+            <Button className="mt-2" type="submit">
+              Search
+            </Button>
           </form>
           <MessageAlert error={error} />
           <p>Found {results.length} Users</p>
@@ -100,6 +164,7 @@ export default function AdminUserSearchPage() {
                   <th>Status</th>
                   <th>Created</th>
                   <th>Last Login</th>
+                  <th>Edit</th>
                   <th>Delete</th>
                 </tr>
               </thead>
@@ -114,6 +179,11 @@ export default function AdminUserSearchPage() {
                     <td>{u.created_at}</td>
                     <td>{u.last_login_at}</td>
                     <td>
+                      <Button variant="link" onClick={() => handleEdit(u)}>
+                        <i className="fas fa-edit"></i>
+                      </Button>
+                    </td>
+                    <td>
                       <Button variant="link" onClick={() => handleDelete(u.id)}>
                         <i className="fas fa-trash text-danger"></i>
                       </Button>
@@ -123,6 +193,12 @@ export default function AdminUserSearchPage() {
               </tbody>
             </Table>
           )}
+          <AdminUserModal
+            show={modalShow}
+            onHide={() => setModalShow(false)}
+            user={editUser}
+            onSaved={handleSaved}
+          />
         </Col>
       </Row>
     </Container>

--- a/server.js
+++ b/server.js
@@ -1,13 +1,13 @@
-require('dotenv').config();
-const express = require('express');
-const session = require('express-session');
-const fs = require('fs');
-const path = require('path');
-const nodemailer = require('nodemailer');
-const db = require('./db');
-var cors = require('cors');
-const crypto = require('crypto');
-const { hashPassword, comparePassword } = require('./auth');
+require("dotenv").config();
+const express = require("express");
+const session = require("express-session");
+const fs = require("fs");
+const path = require("path");
+const nodemailer = require("nodemailer");
+const db = require("./db");
+var cors = require("cors");
+const crypto = require("crypto");
+const { hashPassword, comparePassword } = require("./auth");
 var lunr = require("lunr");
 var lunr_index = require("./lunr_index.json");
 var lunr_pages = require("./lunr_pages.json");
@@ -15,35 +15,51 @@ var lunr_pages = require("./lunr_pages.json");
 const app = express();
 
 // SECURITY SETTINGS
-app.set('trust proxy', 1);
-app.use(cors({
-  origin: process.env.FRONT_URL,
-  credentials: true
-}));
+app.set("trust proxy", 1);
+app.use(
+  cors({
+    origin: process.env.FRONT_URL,
+    credentials: true,
+  }),
+);
 app.use(express.json());
-app.use(session({
-  secret: process.env.SESSION_SECRET,
-  resave: false,
-  saveUninitialized: false,
-  cookie: {
-    httpOnly: true,
-    secure: false, // set to true if using HTTPS
-    maxAge: 86400 * 1000 // 1 day
-  }
-}));
-app.use(function(req, res, next) { // Dump debugging output for each request
-  console.log('SERVER: ===========================================================');
-  console.log('SERVER: In USE', 'req.originalUrl=', req.originalUrl, 'req.ip=', req.ip, 'req.method=', req.method);
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      secure: false, // set to true if using HTTPS
+      maxAge: 86400 * 1000, // 1 day
+    },
+  }),
+);
+app.use(function (req, res, next) {
+  // Dump debugging output for each request
+  console.log(
+    "SERVER: ===========================================================",
+  );
+  console.log(
+    "SERVER: In USE",
+    "req.originalUrl=",
+    req.originalUrl,
+    "req.ip=",
+    req.ip,
+    "req.method=",
+    req.method,
+  );
   next();
 });
-app.use((req, res, next) => { // Check for nasty input
+app.use((req, res, next) => {
+  // Check for nasty input
   var found = req.originalUrl.match(/\/\?\d+/); // Example '/?5129='
   if (found) {
     res.status(500).end();
   } else {
     next();
   }
-})
+});
 
 // SMTP SETTINGS
 const transporter = nodemailer.createTransport({
@@ -52,11 +68,11 @@ const transporter = nodemailer.createTransport({
   secure: false, // false for port 587
   auth: {
     user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS
+    pass: process.env.SMTP_PASS,
   },
   tls: {
-    ciphers: 'SSLv3'
-  }
+    ciphers: "SSLv3",
+  },
 });
 
 /**
@@ -65,60 +81,68 @@ const transporter = nodemailer.createTransport({
  * contents are attached to request
  */
 function authenticationRequired(req, res, next) {
-  const authHeader = req.headers.authorization || '';
+  const authHeader = req.headers.authorization || "";
   const match = authHeader.match(/Bearer (.+)/);
-//  console.log('SERVER: In authenticationRequired', 'authHeader=', authHeader);
-//  console.log('SERVER: In authenticationRequired', 'match=', match);
+  //  console.log('SERVER: In authenticationRequired', 'authHeader=', authHeader);
+  //  console.log('SERVER: In authenticationRequired', 'match=', match);
   if (!match) {
-    sendMessage(res,'','',null,401);
+    sendMessage(res, "", "", null, 401);
     return;
   }
   req.uid = match[1];
-//  console.log('SERVER: In authenticationRequired', 'req.uid=', req.uid);
+  //  console.log('SERVER: In authenticationRequired', 'req.uid=', req.uid);
   next();
 }
 
 async function adminRequired(req, res, next) {
   try {
-    const [rows] = await db.execute('SELECT role FROM user WHERE token = ?', [req.uid]);
-    if (!rows.length || rows[0].role !== 'admin') {
-      sendMessage(res, '', '', null, 401);
+    const [rows] = await db.execute("SELECT role FROM user WHERE token = ?", [
+      req.uid,
+    ]);
+    if (!rows.length || rows[0].role !== "admin") {
+      sendMessage(res, "", "", null, 401);
       return;
     }
     next();
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 }
 
 // Token generator
 function generateToken() {
-  return crypto.randomBytes(32).toString('hex');
+  return crypto.randomBytes(32).toString("hex");
 }
 
 function generateUserToken() {
-  return crypto.randomBytes(15).toString('base64url'); // ~20 characters, URL-safe
+  return crypto.randomBytes(15).toString("base64url"); // ~20 characters, URL-safe
 }
 
 function renderTemplate(templatePath, replacements = {}) {
-  let template = fs.readFileSync(templatePath, 'utf8');
+  let template = fs.readFileSync(templatePath, "utf8");
   for (const [key, value] of Object.entries(replacements)) {
-//    console.log('renderTemplate','key=',key,'value=',value);
-    template = template.replace(new RegExp(`{{${key}}}`, 'g'), value);
+    //    console.log('renderTemplate','key=',key,'value=',value);
+    template = template.replace(new RegExp(`{{${key}}}`, "g"), value);
   }
-//  console.log('renderTemplate','template=',template);
+  //  console.log('renderTemplate','template=',template);
   return template;
 }
 
 async function sendConfirmationEmail(email, first_name, last_name, token) {
   const frontUrl = process.env.FRONT_URL;
   const confirmUrl = `${process.env.FRONT_URL}/confirm?token=${token}`;
-  const html = renderTemplate(path.join(__dirname, 'emails', 'confirm.html'), { email, first_name, last_name, frontUrl, confirmUrl });
+  const html = renderTemplate(path.join(__dirname, "emails", "confirm.html"), {
+    email,
+    first_name,
+    last_name,
+    frontUrl,
+    confirmUrl,
+  });
 
   const mailOptions = {
     from: `"Server NoReply" <${process.env.SMTP_USER}>`,
     to: email,
-    subject: 'Confirm your account',
+    subject: "Confirm your account",
     html,
   };
 
@@ -128,12 +152,18 @@ async function sendConfirmationEmail(email, first_name, last_name, token) {
 async function sendResetEmail(email, first_name, last_name, token) {
   const frontUrl = process.env.FRONT_URL;
   const resetUrl = `${process.env.FRONT_URL}/change-password?token=${token}&email=${email}`;
-  const html = renderTemplate(path.join(__dirname, 'emails', 'reset.html'), { email, first_name, last_name, frontUrl, resetUrl });
+  const html = renderTemplate(path.join(__dirname, "emails", "reset.html"), {
+    email,
+    first_name,
+    last_name,
+    frontUrl,
+    resetUrl,
+  });
 
   const mailOptions = {
     from: `"Server NoReply" <${process.env.SMTP_USER}>`,
     to: email,
-    subject: 'Reset your password',
+    subject: "Reset your password",
     html,
   };
 
@@ -153,8 +183,14 @@ function isValidPassword(password) {
   return lengthOk && hasLower && hasUpper && hasNumber;
 }
 
-function sendMessage(res, message, severity = 'error', field = null, status = 400) {
-//  console.log('sendMessage','message=',message,'severity=',severity,'field=',field,'status=',status);
+function sendMessage(
+  res,
+  message,
+  severity = "error",
+  field = null,
+  status = 400,
+) {
+  //  console.log('sendMessage','message=',message,'severity=',severity,'field=',field,'status=',status);
   const httpStatusCodes = {
     100: "CONTINUE",
     101: "SWITCHING PROTOCOLS",
@@ -167,17 +203,18 @@ function sendMessage(res, message, severity = 'error', field = null, status = 40
     409: "CONFLICT",
     500: "INTERNAL SERVER ERROR",
   };
-  console.log('SERVER: ' + status + ' - ' + httpStatusCodes[status]);
-  if (severity === '' && message === '') {
+  console.log("SERVER: " + status + " - " + httpStatusCodes[status]);
+  if (severity === "" && message === "") {
     return res.status(status).end(); // Return just the status
-  } else if (severity === '' && message !== '') {
+  } else if (severity === "" && message !== "") {
     return res.status(status).json(message).end(); // Return message as data and the status
-  } else if (severity !== '') { // message === '' || message !== ''
+  } else if (severity !== "") {
+    // message === '' || message !== ''
     const response = {
       error: {
         message,
-        severity
-      }
+        severity,
+      },
     };
     if (field) {
       response.error.field = field;
@@ -201,10 +238,10 @@ function sendMessage(res, message, severity = 'error', field = null, status = 40
 
 //==================================================================================================
 // db_size
-app.get('/api/v1/db_size', authenticationRequired, async (req, res) => {
+app.get("/api/v1/db_size", authenticationRequired, async (req, res) => {
   var value;
   var user = req.uid;
-//  console.log('SERVER: In GET /api/v1/db_size', 'user=', user);
+  //  console.log('SERVER: In GET /api/v1/db_size', 'user=', user);
   var stmt = `
 SELECT NOW() AS date_time, s.schema_name AS schema_name, sp.grantee AS user, CAST(ROUND(SUM(COALESCE(t.data_length + t.index_length, 0)) / 1024 / 1024, 3) AS CHAR) AS db_size_mb, sp.has_insert AS has_insert
 FROM information_schema.schemata AS s
@@ -222,275 +259,383 @@ INNER JOIN (
 ) AS sp
 ON s.schema_name = sp.table_schema
 GROUP BY s.schema_name, sp.grantee, sp.has_insert`;
-//  console.log('SERVER:', 'stmt=', stmt);
+  //  console.log('SERVER:', 'stmt=', stmt);
   try {
     const [rows] = await db.execute(stmt);
-//    console.log('SERVER: After SELECT', 'rows=', rows);
+    //    console.log('SERVER: After SELECT', 'rows=', rows);
     if (!rows.length) {
-      value = ['Unknown'];
-      sendMessage(res, value, '', null, 200);
+      value = ["Unknown"];
+      sendMessage(res, value, "", null, 200);
     } else {
-      value = rows.map((row) => { return row.db_size_mb });
-//      console.log('SERVER: After SELECT DISTINCT', 'value=', value);
-      sendMessage(res, value, '', null, 200);
+      value = rows.map((row) => {
+        return row.db_size_mb;
+      });
+      //      console.log('SERVER: After SELECT DISTINCT', 'value=', value);
+      sendMessage(res, value, "", null, 200);
     }
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // designtypes
-app.get('/api/v1/designtypes', authenticationRequired, async (req, res) => {
+app.get("/api/v1/designtypes", authenticationRequired, async (req, res) => {
   var value;
   var user = req.uid;
-//  console.log('SERVER: In GET /api/v1/designtypes', 'user=', user);
-  var stmt = 'SELECT DISTINCT type FROM design WHERE (user = \'' + user + '\' OR user IS NULL) ORDER BY type';
-//  console.log('SERVER:', 'stmt=', stmt);
+  //  console.log('SERVER: In GET /api/v1/designtypes', 'user=', user);
+  var stmt =
+    "SELECT DISTINCT type FROM design WHERE (user = '" +
+    user +
+    "' OR user IS NULL) ORDER BY type";
+  //  console.log('SERVER:', 'stmt=', stmt);
   try {
     const [rows] = await db.execute(stmt);
-//    console.log('SERVER: After SELECT', 'rows=', rows);
-    value = rows.map((row) => { return row.type });
-//    console.log('SERVER: After SELECT DISTINCT', 'value=', value);
-    sendMessage(res, value, '', null, 200);
+    //    console.log('SERVER: After SELECT', 'rows=', rows);
+    value = rows.map((row) => {
+      return row.type;
+    });
+    //    console.log('SERVER: After SELECT DISTINCT', 'value=', value);
+    sendMessage(res, value, "", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // designtypes/:type/designs
-app.get('/api/v1/designtypes/:type/designs', authenticationRequired, async (req, res) => {
-  var value;
-  var user = req.uid;
-  var type = req.params['type'];
-//  console.log('SERVER: In GET /api/v1/designtypes/' + type + '/designs', 'user=', user);
-  var stmt = 'SELECT user, name FROM design WHERE (user = \'' + user + '\' OR user IS NULL) AND type = \'' + type + '\' ORDER BY name ASC, user DESC';
-//  console.log('SERVER:', 'stmt=', stmt);
-  try {
-    const [rows] = await db.execute(stmt);
-//    console.log('SERVER: After SELECT', 'rows=', rows);
-    value = rows.map((row) => { return { user: row.user, name: row.name } });
-//    console.log('SERVER: After SELECT', 'value=', value);
-    sendMessage(res, value, '', null, 200);
-  } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
-  }
-});
+app.get(
+  "/api/v1/designtypes/:type/designs",
+  authenticationRequired,
+  async (req, res) => {
+    var value;
+    var user = req.uid;
+    var type = req.params["type"];
+    //  console.log('SERVER: In GET /api/v1/designtypes/' + type + '/designs', 'user=', user);
+    var stmt =
+      "SELECT user, name FROM design WHERE (user = '" +
+      user +
+      "' OR user IS NULL) AND type = '" +
+      type +
+      "' ORDER BY name ASC, user DESC";
+    //  console.log('SERVER:', 'stmt=', stmt);
+    try {
+      const [rows] = await db.execute(stmt);
+      //    console.log('SERVER: After SELECT', 'rows=', rows);
+      value = rows.map((row) => {
+        return { user: row.user, name: row.name };
+      });
+      //    console.log('SERVER: After SELECT', 'value=', value);
+      sendMessage(res, value, "", null, 200);
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
+    }
+  },
+);
 
 //==================================================================================================
 // designtypes/:type/designs/:name
-app.get('/api/v1/designtypes/:type/designs/:name', authenticationRequired, async (req, res) => {
-  var type;
-  var value;
-  var user = req.uid;
-  var type = req.params['type'];
-  var name = req.params['name'];
-//  console.log('SERVER: In GET /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
-  var stmt = 'SELECT * FROM design WHERE (user = \'' + user + '\' OR user IS NULL) AND type = \'' + type + '\' AND name = \'' + name + '\' ORDER BY user DESC';
-//  console.log('SERVER:', 'stmt=', stmt);
-  try {
-    const [rows] = await db.execute(stmt);
-//    console.log('SERVER: After SELECT', 'rows=', rows);
-    if (!rows.length) {
-      sendMessage(res, '', '', null, 404);
-    } else {
-//      console.log('SERVER: After SELECT', 'rows[0]=', rows[0]);
-      type = rows[0].type; // Get type from the JSON blob
-//      console.log('SERVER: After SELECT', 'user=', user, 'name=', name, 'type=', type);
-      value = JSON.parse(rows[0].value); // Get value from the JSON blob
-      value.type = type; // Insert type into blob
-//      console.log('SERVER: After SELECT', 'value=', value);
-      sendMessage(res, value, '', null, 200);
+app.get(
+  "/api/v1/designtypes/:type/designs/:name",
+  authenticationRequired,
+  async (req, res) => {
+    var type;
+    var value;
+    var user = req.uid;
+    var type = req.params["type"];
+    var name = req.params["name"];
+    //  console.log('SERVER: In GET /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
+    var stmt =
+      "SELECT * FROM design WHERE (user = '" +
+      user +
+      "' OR user IS NULL) AND type = '" +
+      type +
+      "' AND name = '" +
+      name +
+      "' ORDER BY user DESC";
+    //  console.log('SERVER:', 'stmt=', stmt);
+    try {
+      const [rows] = await db.execute(stmt);
+      //    console.log('SERVER: After SELECT', 'rows=', rows);
+      if (!rows.length) {
+        sendMessage(res, "", "", null, 404);
+      } else {
+        //      console.log('SERVER: After SELECT', 'rows[0]=', rows[0]);
+        type = rows[0].type; // Get type from the JSON blob
+        //      console.log('SERVER: After SELECT', 'user=', user, 'name=', name, 'type=', type);
+        value = JSON.parse(rows[0].value); // Get value from the JSON blob
+        value.type = type; // Insert type into blob
+        //      console.log('SERVER: After SELECT', 'value=', value);
+        sendMessage(res, value, "", null, 200);
+      }
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
     }
-  } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
-  }
-});
+  },
+);
 
 //==================================================================================================
 // designtypes/:type/designs/:name - create new
-app.post('/api/v1/designtypes/:type/designs/:name', authenticationRequired, async (req, res) => { // Create New
-  var value;
-  var user = req.uid;
-  var type = req.body.type;
-  var name = req.params['name'];
-//  console.log('SERVER: In POST /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
-  if (req.uid === "null" || req.body === undefined || req.body.length === 0 || req.body.type === undefined || req.body.type !== req.params['type']) {
-    sendMessage(res, '', '', null, 400);
-  } else {
-    delete req.body.type; // Do not save the type in the blob
-    value = JSON.stringify(req.body); // Convert blob to string
-    var stmt = 'SELECT COUNT(*) AS count FROM design WHERE user = \'' + user + '\' AND type = \'' + type + '\' AND name = \'' + name + '\'';
-//    console.log('SERVER:', 'stmt=', stmt);
-    try {
-      const [rows] = await db.execute(stmt);
-//      console.log('SERVER: After SELECT', 'rows=', rows);
-      if (rows[0].count > 0) {
-        sendMessage(res, '', '', null, 400);
-      } else {
-//        console.log('SERVER: In POST /api/v1/designs/' + name, 'type=', type, 'value=', value);
-        value = value.replace(/[']/ig, "''") // replace one single quote with an two single quotes throughout
-          .replace(/\\n/g, "\\\\n")
-          .replace(/\\'/g, "\\\\'")
-          .replace(/\\"/g, '\\\\"')
-          .replace(/\\&/g, "\\\\&")
-          .replace(/\\r/g, "\\\\r")
-          .replace(/\\t/g, "\\\\t")
-          .replace(/\\b/g, "\\\\b")
-          .replace(/\\f/g, "\\\\f");
-        var stmt = 'INSERT INTO design (user, type, name, value) VALUES (\'' + user + '\',\'' + type + '\',\'' + name + '\',\'' + value + '\')';
-//        console.log('SERVER:', 'stmt=', stmt);
-        try {
-          const [rows] = await db.execute(stmt);
-//          console.log('SERVER: After INSERT', 'rows=', rows);
-          value = {};
-//          console.log('SERVER: After INSERT', 'value=', value);
-          sendMessage(res, value, '', null, 200);
-        } catch (err) {
-          sendMessage(res, err, 'error', null, 500);
+app.post(
+  "/api/v1/designtypes/:type/designs/:name",
+  authenticationRequired,
+  async (req, res) => {
+    // Create New
+    var value;
+    var user = req.uid;
+    var type = req.body.type;
+    var name = req.params["name"];
+    //  console.log('SERVER: In POST /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
+    if (
+      req.uid === "null" ||
+      req.body === undefined ||
+      req.body.length === 0 ||
+      req.body.type === undefined ||
+      req.body.type !== req.params["type"]
+    ) {
+      sendMessage(res, "", "", null, 400);
+    } else {
+      delete req.body.type; // Do not save the type in the blob
+      value = JSON.stringify(req.body); // Convert blob to string
+      var stmt =
+        "SELECT COUNT(*) AS count FROM design WHERE user = '" +
+        user +
+        "' AND type = '" +
+        type +
+        "' AND name = '" +
+        name +
+        "'";
+      //    console.log('SERVER:', 'stmt=', stmt);
+      try {
+        const [rows] = await db.execute(stmt);
+        //      console.log('SERVER: After SELECT', 'rows=', rows);
+        if (rows[0].count > 0) {
+          sendMessage(res, "", "", null, 400);
+        } else {
+          //        console.log('SERVER: In POST /api/v1/designs/' + name, 'type=', type, 'value=', value);
+          value = value
+            .replace(/[']/gi, "''") // replace one single quote with an two single quotes throughout
+            .replace(/\\n/g, "\\\\n")
+            .replace(/\\'/g, "\\\\'")
+            .replace(/\\"/g, '\\\\"')
+            .replace(/\\&/g, "\\\\&")
+            .replace(/\\r/g, "\\\\r")
+            .replace(/\\t/g, "\\\\t")
+            .replace(/\\b/g, "\\\\b")
+            .replace(/\\f/g, "\\\\f");
+          var stmt =
+            "INSERT INTO design (user, type, name, value) VALUES ('" +
+            user +
+            "','" +
+            type +
+            "','" +
+            name +
+            "','" +
+            value +
+            "')";
+          //        console.log('SERVER:', 'stmt=', stmt);
+          try {
+            const [rows] = await db.execute(stmt);
+            //          console.log('SERVER: After INSERT', 'rows=', rows);
+            value = {};
+            //          console.log('SERVER: After INSERT', 'value=', value);
+            sendMessage(res, value, "", null, 200);
+          } catch (err) {
+            sendMessage(res, err, "error", null, 500);
+          }
         }
+      } catch (err) {
+        sendMessage(res, err, "error", null, 500);
       }
-    } catch (err) {
-      sendMessage(res, err, 'error', null, 500);
     }
-  }
-});
+  },
+);
 
 //==================================================================================================
 // designtypes/:type/designs/:name - update existing
-app.put('/api/v1/designtypes/:type/designs/:name', authenticationRequired, async (req, res) => { // Update Existing
-  var value;
-  var user = req.uid;
-  var type = req.body.type;
-  var name = req.params['name'];
-//  console.log('SERVER: In PUT /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
-  if (req.uid === "null" || req.body === undefined || req.body.length === 0 || req.body.type === undefined || req.body.type !== req.params['type']) {
-    sendMessage(res, '', '', null, 400);
-  } else {
-    delete req.body.type; // Do not save the type in the blob
-    value = JSON.stringify(req.body); // Convert blob to string
-    var stmt = 'SELECT COUNT(*) AS count FROM design WHERE user = \'' + user + '\' AND type = \'' + type + '\' AND name = \'' + name + '\'';
-//    console.log('SERVER:', 'stmt=', stmt);
-    try {
-      const [rows] = await db.execute(stmt);
-//      console.log('SERVER: After SELECT', 'rows=', rows);
-//      console.log('SERVER: In PUT /api/v1/designs/' + name, 'type=', type, 'value=', value);
-      if (rows[0].count === 0) {
-        sendMessage(res, '', '', null, 404);
-      } else {
-        value = value.replace(/[']/ig, "''") // replace one single quote with an two single quotes throughout
-          .replace(/\\n/g, "\\\\n")
-          .replace(/\\'/g, "\\\\'")
-          .replace(/\\"/g, '\\\\"')
-          .replace(/\\&/g, "\\\\&")
-          .replace(/\\r/g, "\\\\r")
-          .replace(/\\t/g, "\\\\t")
-          .replace(/\\b/g, "\\\\b")
-          .replace(/\\f/g, "\\\\f");
-        var stmt = 'UPDATE design SET value = \'' + value + '\' WHERE user = \'' + user + '\' AND type = \'' + type + '\' AND name = \'' + name + '\'';
-//        console.log('SERVER:', 'stmt=', stmt);
-        try {
-          const [rows] = await db.execute(stmt);
-//          console.log('SERVER: After UPDATE', 'rows=', rows);
-          value = {};
-//          console.log('SERVER: After UPDATE', 'value=', value);
-          sendMessage(res, value, '', null, 200);
-        } catch (err) {
-          sendMessage(res, err, 'error', null, 500);
+app.put(
+  "/api/v1/designtypes/:type/designs/:name",
+  authenticationRequired,
+  async (req, res) => {
+    // Update Existing
+    var value;
+    var user = req.uid;
+    var type = req.body.type;
+    var name = req.params["name"];
+    //  console.log('SERVER: In PUT /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
+    if (
+      req.uid === "null" ||
+      req.body === undefined ||
+      req.body.length === 0 ||
+      req.body.type === undefined ||
+      req.body.type !== req.params["type"]
+    ) {
+      sendMessage(res, "", "", null, 400);
+    } else {
+      delete req.body.type; // Do not save the type in the blob
+      value = JSON.stringify(req.body); // Convert blob to string
+      var stmt =
+        "SELECT COUNT(*) AS count FROM design WHERE user = '" +
+        user +
+        "' AND type = '" +
+        type +
+        "' AND name = '" +
+        name +
+        "'";
+      //    console.log('SERVER:', 'stmt=', stmt);
+      try {
+        const [rows] = await db.execute(stmt);
+        //      console.log('SERVER: After SELECT', 'rows=', rows);
+        //      console.log('SERVER: In PUT /api/v1/designs/' + name, 'type=', type, 'value=', value);
+        if (rows[0].count === 0) {
+          sendMessage(res, "", "", null, 404);
+        } else {
+          value = value
+            .replace(/[']/gi, "''") // replace one single quote with an two single quotes throughout
+            .replace(/\\n/g, "\\\\n")
+            .replace(/\\'/g, "\\\\'")
+            .replace(/\\"/g, '\\\\"')
+            .replace(/\\&/g, "\\\\&")
+            .replace(/\\r/g, "\\\\r")
+            .replace(/\\t/g, "\\\\t")
+            .replace(/\\b/g, "\\\\b")
+            .replace(/\\f/g, "\\\\f");
+          var stmt =
+            "UPDATE design SET value = '" +
+            value +
+            "' WHERE user = '" +
+            user +
+            "' AND type = '" +
+            type +
+            "' AND name = '" +
+            name +
+            "'";
+          //        console.log('SERVER:', 'stmt=', stmt);
+          try {
+            const [rows] = await db.execute(stmt);
+            //          console.log('SERVER: After UPDATE', 'rows=', rows);
+            value = {};
+            //          console.log('SERVER: After UPDATE', 'value=', value);
+            sendMessage(res, value, "", null, 200);
+          } catch (err) {
+            sendMessage(res, err, "error", null, 500);
+          }
         }
+      } catch (err) {
+        sendMessage(res, err, "error", null, 500);
       }
-    } catch (err) {
-      sendMessage(res, err, 'error', null, 500);
     }
-  }
-});
+  },
+);
 
 //==================================================================================================
 // designtypes/:type/designs/:name
-app.delete('/api/v1/designtypes/:type/designs/:name', authenticationRequired, async (req, res) => {
-  var value;
-  var user = req.uid;
-  var type = req.params['type'];
-  var name = req.params['name'];
-//  console.log('SERVER: In DELETE /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
-  if (req.uid === "null") {
-    sendMessage(res, '', '', null, 400);
-  } else {
-    var stmt = 'SELECT COUNT(*) AS count FROM design WHERE user = \'' + user + '\' AND type = \'' + type + '\' AND name = \'' + name + '\'';
-//    console.log('SERVER:', 'stmt=', stmt);
-    try {
-      const [rows] = await db.execute(stmt);
-//      console.log('SERVER: After SELECT', 'rows=', rows);
-      if (rows[0].count === 0) {
-        sendMessage(res, '', '', null, 404);
-      } else {
-        var stmt = 'DELETE FROM design WHERE user = \'' + user + '\' AND type = \'' + type + '\' AND name = \'' + name + '\'';
-//        console.log('SERVER:', 'stmt=', stmt);
-        try {
-          const [rows] = await db.execute(stmt);
-//          console.log('SERVER: After DELETE', 'rows=', rows);
-          value = {};
-//          console.log('SERVER: After DELETE', 'value=', value);
-          sendMessage(res, value, '', null, 200);
-        } catch (err) {
-          res.status(500).end();
-          sendMessage(res, err, 'error', null, 500);
+app.delete(
+  "/api/v1/designtypes/:type/designs/:name",
+  authenticationRequired,
+  async (req, res) => {
+    var value;
+    var user = req.uid;
+    var type = req.params["type"];
+    var name = req.params["name"];
+    //  console.log('SERVER: In DELETE /api/v1/designtypes/' + type + '/designs/' + name, 'user=', user);
+    if (req.uid === "null") {
+      sendMessage(res, "", "", null, 400);
+    } else {
+      var stmt =
+        "SELECT COUNT(*) AS count FROM design WHERE user = '" +
+        user +
+        "' AND type = '" +
+        type +
+        "' AND name = '" +
+        name +
+        "'";
+      //    console.log('SERVER:', 'stmt=', stmt);
+      try {
+        const [rows] = await db.execute(stmt);
+        //      console.log('SERVER: After SELECT', 'rows=', rows);
+        if (rows[0].count === 0) {
+          sendMessage(res, "", "", null, 404);
+        } else {
+          var stmt =
+            "DELETE FROM design WHERE user = '" +
+            user +
+            "' AND type = '" +
+            type +
+            "' AND name = '" +
+            name +
+            "'";
+          //        console.log('SERVER:', 'stmt=', stmt);
+          try {
+            const [rows] = await db.execute(stmt);
+            //          console.log('SERVER: After DELETE', 'rows=', rows);
+            value = {};
+            //          console.log('SERVER: After DELETE', 'value=', value);
+            sendMessage(res, value, "", null, 200);
+          } catch (err) {
+            res.status(500).end();
+            sendMessage(res, err, "error", null, 500);
+          }
         }
+      } catch (err) {
+        sendMessage(res, err, "error", null, 500);
       }
-    } catch (err) {
-      sendMessage(res, err, 'error', null, 500);
     }
-  }
-});
+  },
+);
 
 //==================================================================================================
 // usage_log
-app.post('/api/v1/usage_log', async (req, res) => {
+app.post("/api/v1/usage_log", async (req, res) => {
   var ip_address;
   var note;
-  ip_address = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  ip_address = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
   note = JSON.stringify(req.body); // Convert blob to string
-//  console.log('SERVER: In POST /api/v1/usage_log', 'ip_address=' + ip_address + ' note=', note);
-  note = note.replace(/[']/ig, "''"); // replace one single quote with an two single quotes throughout
-  var stmt = 'INSERT INTO usage_log (ip_address, note) VALUES (\'' + ip_address + '\',\'' + note + '\')';
-//  console.log('SERVER:', 'stmt=', stmt);
+  //  console.log('SERVER: In POST /api/v1/usage_log', 'ip_address=' + ip_address + ' note=', note);
+  note = note.replace(/[']/gi, "''"); // replace one single quote with an two single quotes throughout
+  var stmt =
+    "INSERT INTO usage_log (ip_address, note) VALUES ('" +
+    ip_address +
+    "','" +
+    note +
+    "')";
+  //  console.log('SERVER:', 'stmt=', stmt);
   try {
     const [rows] = await db.execute(stmt);
-//    console.log('SERVER: After INSERT', 'rows=', rows);
+    //    console.log('SERVER: After INSERT', 'rows=', rows);
     var value = {};
-//    console.log('SERVER: After INSERT', 'value=', value);
-    sendMessage(res,value,'',null,200);
+    //    console.log('SERVER: After INSERT', 'value=', value);
+    sendMessage(res, value, "", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // SEARCH
-const SENTENCE_SEPARATOR = ' <> ';
+const SENTENCE_SEPARATOR = " <> ";
 
 var searchIndex = lunr.Index.load(lunr_index);
 
-app.get('/api/v1/search', (req, res) => {
-//  console.log('SERVER:', 'req=', req);
+app.get("/api/v1/search", (req, res) => {
+  //  console.log('SERVER:', 'req=', req);
   var terms = req.query.terms;
   const results = searchSite(terms);
-//  console.log('SERVER:', 'results=', results);
-  sendMessage(res,results,'',null,200);
+  //  console.log('SERVER:', 'results=', results);
+  sendMessage(res, results, "", null, 200);
 });
 
 function searchSite(query) {
   let results = getSearchResults(query);
-  return results.length
-    ? results
-    : [];
+  return results.length ? results : [];
 }
 
 function getSearchResults(query) {
   return searchIndex.search(query).flatMap((hit) => {
     if (hit.ref == "undefined") return [];
-    let pageMatch = JSON.parse(JSON.stringify(lunr_pages.filter((page) => page.href === hit.ref)[0])); // Make clone
+    let pageMatch = JSON.parse(
+      JSON.stringify(lunr_pages.filter((page) => page.href === hit.ref)[0]),
+    ); // Make clone
     pageMatch.score = hit.score;
     pageMatch.matchData = hit.matchData;
     pageMatch.sentence_text = createSentenceSearchResult(pageMatch);
@@ -500,74 +645,86 @@ function getSearchResults(query) {
 }
 
 function createSentenceSearchResult(pageMatch) {
-//  console.log('createSentenceSearchResult', 'pageMatch=', pageMatch);
-//  console.log('createSentenceSearchResult', 'pageMatch.href=', pageMatch.href);
+  //  console.log('createSentenceSearchResult', 'pageMatch=', pageMatch);
+  //  console.log('createSentenceSearchResult', 'pageMatch.href=', pageMatch.href);
   let sentenceData = [];
-  Object.keys(pageMatch.matchData.metadata).forEach(function(term) {
-//    console.log('createSentenceSearchResult', 'term=', term);
-    Object.keys(pageMatch.matchData.metadata[term]).forEach(function(fieldName) {
-      if (fieldName === 'sentence_text') { // Only highlight content
-//        console.log('createSentenceSearchResult', 'fieldName=', fieldName);
-        let hit = pageMatch[fieldName];
-//        console.log('createSentenceSearchResult', 'hit=', hit);
-        pageMatch.matchData.metadata[term][fieldName].position.forEach((position) => {
-//          console.log('createSentenceSearchResult', 'position=', position);
-          let lio = hit.lastIndexOf(SENTENCE_SEPARATOR, position[0]) + SENTENCE_SEPARATOR.length;
-          if (sentenceData[lio] === undefined) {
-            sentenceData[lio] = [];
-          }
-          let position_clone = Object.assign({}, position); // clone it
-          position_clone[0] = position_clone[0] - lio;
-//          console.log('createSentenceSearchResult', 'lio=', lio, 'position=', position);
-          sentenceData[lio].push(position_clone);
-          sentenceData[lio].sort((a, b) => a[0] - b[0]); // Put in position order
-        });
-      }
-    });
+  Object.keys(pageMatch.matchData.metadata).forEach(function (term) {
+    //    console.log('createSentenceSearchResult', 'term=', term);
+    Object.keys(pageMatch.matchData.metadata[term]).forEach(
+      function (fieldName) {
+        if (fieldName === "sentence_text") {
+          // Only highlight content
+          //        console.log('createSentenceSearchResult', 'fieldName=', fieldName);
+          let hit = pageMatch[fieldName];
+          //        console.log('createSentenceSearchResult', 'hit=', hit);
+          pageMatch.matchData.metadata[term][fieldName].position.forEach(
+            (position) => {
+              //          console.log('createSentenceSearchResult', 'position=', position);
+              let lio =
+                hit.lastIndexOf(SENTENCE_SEPARATOR, position[0]) +
+                SENTENCE_SEPARATOR.length;
+              if (sentenceData[lio] === undefined) {
+                sentenceData[lio] = [];
+              }
+              let position_clone = Object.assign({}, position); // clone it
+              position_clone[0] = position_clone[0] - lio;
+              //          console.log('createSentenceSearchResult', 'lio=', lio, 'position=', position);
+              sentenceData[lio].push(position_clone);
+              sentenceData[lio].sort((a, b) => a[0] - b[0]); // Put in position order
+            },
+          );
+        }
+      },
+    );
   });
-//  console.log('createSentenceSearchResult', 'sentenceData=', sentenceData);
+  //  console.log('createSentenceSearchResult', 'sentenceData=', sentenceData);
   let searchResultText = "";
-  let style_color = 'style="color:' + getColorForSearchResult(pageMatch.score) + '"'
+  let style_color =
+    'style="color:' + getColorForSearchResult(pageMatch.score) + '"';
   let hit = pageMatch.sentence_text;
-  Object.keys(sentenceData).forEach(function(lio) {
+  Object.keys(sentenceData).forEach(function (lio) {
     let io = hit.indexOf(SENTENCE_SEPARATOR, lio);
-//    console.log('createSentenceSearchResult', 'lio=', lio, 'io=', io);
+    //    console.log('createSentenceSearchResult', 'lio=', lio, 'io=', io);
     let offset = 0;
     let sentence = hit.slice(lio, io);
     sentenceData[lio].forEach((position) => {
-//      console.log('createSentenceSearchResult', 'offset=', offset, 'position=', position);
+      //      console.log('createSentenceSearchResult', 'offset=', offset, 'position=', position);
       let prefix = sentence.slice(0, offset + position[0]);
       let strong_prefix = `<strong ${style_color}>`;
       let text = sentence.substr(offset + position[0], position[1]);
-      let strong_suffix = '</strong>';
+      let strong_suffix = "</strong>";
       let suffix = sentence.slice(offset + position[0] + position[1]);
-//      console.log('createSentenceSearchResult', 'prefix=', prefix, 'strong_prefix=', strong_prefix, 'text=', text, ',strong_suffix=', strong_suffix, 'suffix=', suffix);
+      //      console.log('createSentenceSearchResult', 'prefix=', prefix, 'strong_prefix=', strong_prefix, 'text=', text, ',strong_suffix=', strong_suffix, 'suffix=', suffix);
       sentence = prefix + strong_prefix + text + strong_suffix + suffix;
       offset += strong_prefix.length + strong_suffix.length;
     });
-    let ellipsis = ' ... ';
+    let ellipsis = " ... ";
     searchResultText += sentence + ellipsis;
   });
-//  console.log('createSentenceSearchResult', 'searchResultText=', searchResultText);
+  //  console.log('createSentenceSearchResult', 'searchResultText=', searchResultText);
   return searchResultText;
 }
 
 function createHighlightSearchResult(pageMatch) {
-//  console.log('createHighlightSearchResult', 'result=', result, 'pageMatch=', pageMatch);
+  //  console.log('createHighlightSearchResult', 'result=', result, 'pageMatch=', pageMatch);
   let searchResultHighlights = [];
-  Object.keys(pageMatch.matchData.metadata).forEach(function(term) {
-//    console.log('createHighlightSearchResult', 'term=', term);
-    Object.keys(pageMatch.matchData.metadata[term]).forEach(function(fieldName) {
-//      console.log('createHighlightSearchResult', 'fieldName=', fieldName);
-      if (fieldName === 'highlight_text') {
-        pageMatch.matchData.metadata[term][fieldName].position.forEach((position) => {
-//          console.log('createHighlightSearchResult', 'position=', position);
-          searchResultHighlights.push(position);
-        });
-      }
-    });
+  Object.keys(pageMatch.matchData.metadata).forEach(function (term) {
+    //    console.log('createHighlightSearchResult', 'term=', term);
+    Object.keys(pageMatch.matchData.metadata[term]).forEach(
+      function (fieldName) {
+        //      console.log('createHighlightSearchResult', 'fieldName=', fieldName);
+        if (fieldName === "highlight_text") {
+          pageMatch.matchData.metadata[term][fieldName].position.forEach(
+            (position) => {
+              //          console.log('createHighlightSearchResult', 'position=', position);
+              searchResultHighlights.push(position);
+            },
+          );
+        }
+      },
+    );
   });
-//  console.log('createHighlightSearchResult', 'searchResultHighlights=', searchResultHighlights);
+  //  console.log('createHighlightSearchResult', 'searchResultHighlights=', searchResultHighlights);
   return searchResultHighlights;
 }
 
@@ -589,342 +746,616 @@ function adjustSat(sat1, sat2, score) {
 
 //==================================================================================================
 // REGISTER
-app.post('/api/v1/register', async (req, res) => {
+app.post("/api/v1/register", async (req, res) => {
   const { email, password, first_name, last_name } = req.body;
-//  console.log('/register','email=',email,'password=',password,'first_name=',first_name,'last_name=',last_name);
+  //  console.log('/register','email=',email,'password=',password,'first_name=',first_name,'last_name=',last_name);
 
   if (!isValidEmail(email)) {
-    sendMessage(res, 'Invalid email address format.', 'error', 'email', 400);
+    sendMessage(res, "Invalid email address format.", "error", "email", 400);
     return;
   }
 
   if (!isValidPassword(password)) {
-    sendMessage(res, 'Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.', 'error', 'password', 400);
+    sendMessage(
+      res,
+      "Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.",
+      "error",
+      "password",
+      400,
+    );
     return;
   }
 
   const confirmationToken = generateToken();
   const local = new Date(Date.now() + 60 * 60 * 1000); // UTC + 1 hour
-  const expiresAt = new Date(local.getTime() + local.getTimezoneOffset() * 60000); // Fudge
-//  console.log('/register','expiresAt=',expiresAt);
+  const expiresAt = new Date(
+    local.getTime() + local.getTimezoneOffset() * 60000,
+  ); // Fudge
+  //  console.log('/register','expiresAt=',expiresAt);
 
   try {
     // Does email already exists
-    const [rows] = await db.execute('SELECT * FROM user WHERE email = ?', [email]);
-//    console.log('rows=',rows);
+    const [rows] = await db.execute("SELECT * FROM user WHERE email = ?", [
+      email,
+    ]);
+    //    console.log('rows=',rows);
     if (rows.length) {
-      sendMessage(res, 'Duplicate email.', 'error', null, 409);
+      sendMessage(res, "Duplicate email.", "error", null, 409);
       return;
     }
 
     // Create new 'inactive' user with email and password, and confirmation token
     const hashed = await hashPassword(password);
-    await db.execute('INSERT INTO user (email, password, first_name, last_name, role, token, status) VALUES (?, ?, ?, ?, ?, ?, ?)', [email, hashed, first_name, last_name, 'user', null, 'inactive']);
-    await db.execute('INSERT INTO token (token, email, type, expires_at) VALUES (?, ?, ?, ?)', [confirmationToken, email, 'confirm', expiresAt]);
+    await db.execute(
+      "INSERT INTO user (email, password, first_name, last_name, role, token, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      [email, hashed, first_name, last_name, "user", null, "inactive"],
+    );
+    await db.execute(
+      "INSERT INTO token (token, email, type, expires_at) VALUES (?, ?, ?, ?)",
+      [confirmationToken, email, "confirm", expiresAt],
+    );
 
     // Send confirmation email
     try {
-      await sendConfirmationEmail(email, first_name, last_name, confirmationToken);
-      sendMessage(res, 'Registration confirmation email sent.', 'info', null, 200);
+      await sendConfirmationEmail(
+        email,
+        first_name,
+        last_name,
+        confirmationToken,
+      );
+      sendMessage(
+        res,
+        "Registration confirmation email sent.",
+        "info",
+        null,
+        200,
+      );
     } catch (err) {
-      sendMessage(res, err.response, 'error', null, 500);
+      sendMessage(res, err.response, "error", null, 500);
     }
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // CONFIRM
-app.get('/api/v1/confirm', async (req, res) => {
+app.get("/api/v1/confirm", async (req, res) => {
   const { token } = req.query;
-//  console.log('token=',token);
+  //  console.log('token=',token);
   try {
     // Does a matching confirmation token exist
-    const [rows] = await db.execute('SELECT email FROM token WHERE token = ? AND type = ? AND expires_at > NOW()', [token, 'confirm']);
-//    console.log('/api/v1/confirm','rows=',rows,'rows.length=',rows.length,'!rows.length=',!rows.length);
+    const [rows] = await db.execute(
+      "SELECT email FROM token WHERE token = ? AND type = ? AND expires_at > NOW()",
+      [token, "confirm"],
+    );
+    //    console.log('/api/v1/confirm','rows=',rows,'rows.length=',rows.length,'!rows.length=',!rows.length);
     if (!rows.length) {
-      sendMessage(res, 'No outstanding registration exists or has expired.', 'error', null, 401);
+      sendMessage(
+        res,
+        "No outstanding registration exists or has expired.",
+        "error",
+        null,
+        401,
+      );
       return;
     }
 
     // If token is null update with a new one, change the user startus to 'active', and delete the token
     const email = rows[0].email;
     const userToken = generateUserToken();
-    await db.execute('UPDATE user SET token = ? WHERE email = ? AND token IS NULL', [userToken, email]);
-    await db.execute('UPDATE user SET status = ? WHERE email = ?', ['active', email]);
-    await db.execute('DELETE FROM token WHERE token = ?', [token]);
-    sendMessage(res, 'Registration confirmed.', 'info', null, 200);
+    await db.execute(
+      "UPDATE user SET token = ? WHERE email = ? AND token IS NULL",
+      [userToken, email],
+    );
+    await db.execute("UPDATE user SET status = ? WHERE email = ?", [
+      "active",
+      email,
+    ]);
+    await db.execute("DELETE FROM token WHERE token = ?", [token]);
+    sendMessage(res, "Registration confirmed.", "info", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // HAS PASSWORD
-app.get('/api/v1/has-password', async (req, res) => {
+app.get("/api/v1/has-password", async (req, res) => {
   const { email } = req.query;
-//  console.log('/api/v1/has-password','email=',email);
+  //  console.log('/api/v1/has-password','email=',email);
   try {
     // Does user exist?
-    const [rows] = await db.execute('SELECT * FROM user WHERE email = ?', [email]);
+    const [rows] = await db.execute("SELECT * FROM user WHERE email = ?", [
+      email,
+    ]);
     if (!rows.length) {
-      sendMessage(res, 'Unknown email or password, or inactive account.', 'error', null, 401);
+      sendMessage(
+        res,
+        "Unknown email or password, or inactive account.",
+        "error",
+        null,
+        401,
+      );
       return;
     }
-    const hasPassword = rows.length > 0 && rows[0].password!== null;
-//    console.log('/api/v1/has-password','hasPassword=',hasPassword);
-    sendMessage(res, { hasPassword }, '', null, 200);
+    const hasPassword = rows.length > 0 && rows[0].password !== null;
+    //    console.log('/api/v1/has-password','hasPassword=',hasPassword);
+    sendMessage(res, { hasPassword }, "", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // LOGIN
-app.post('/api/v1/login', async (req, res) => {
+app.post("/api/v1/login", async (req, res) => {
   const { email, password } = req.body;
-//  console.log('/api/v1/login','email=',email,'password=',password);
+  //  console.log('/api/v1/login','email=',email,'password=',password);
 
   if (!isValidEmail(email)) {
-    sendMessage(res, 'Invalid email address format.', 'error', 'email', 400);
+    sendMessage(res, "Invalid email address format.", "error", "email", 400);
     return;
   }
 
   if (!isValidPassword(password)) {
-    sendMessage(res, 'Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.', 'error', 'password', 400);
+    sendMessage(
+      res,
+      "Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.",
+      "error",
+      "password",
+      400,
+    );
     return;
   }
   try {
     // Does user exist?
-    const [rows] = await db.execute('SELECT * FROM user WHERE email = ? AND status = ?', [email, 'active']);
-//    console.log('/api/v1/login','rows=',rows);
+    const [rows] = await db.execute(
+      "SELECT * FROM user WHERE email = ? AND status = ?",
+      [email, "active"],
+    );
+    //    console.log('/api/v1/login','rows=',rows);
     const user = rows[0];
-    const match = user && await comparePassword(password, user.password);
-//    console.log('/api/v1/login','match=',match);
-    if (!match || user.status !== 'active') {
-      return sendMessage(res, 'Unknown email or password, or inactive account.', 'error', null, 401);
+    const match = user && (await comparePassword(password, user.password));
+    //    console.log('/api/v1/login','match=',match);
+    if (!match || user.status !== "active") {
+      return sendMessage(
+        res,
+        "Unknown email or password, or inactive account.",
+        "error",
+        null,
+        401,
+      );
     }
 
-    await db.query('UPDATE user SET last_login_at = NOW() WHERE id = ?', [user.id]);
-    req.session.user = { email: user.email, token: user.token, first_name: user.first_name, last_name: user.last_name, isAuthenticated: true, isAdmin: user.role === 'admin' };
-    sendMessage(res, 'Successful login.', 'info', null, 200);
+    await db.query("UPDATE user SET last_login_at = NOW() WHERE id = ?", [
+      user.id,
+    ]);
+    req.session.user = {
+      email: user.email,
+      token: user.token,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      isAuthenticated: true,
+      isAdmin: user.role === "admin",
+    };
+    sendMessage(res, "Successful login.", "info", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // CHECK SESSION
-app.get('/api/v1/me', (req, res) => {
+app.get("/api/v1/me", (req, res) => {
   if (req.session.user) {
-//    console.log('/me','req.session.user=',req.session.user);
-    sendMessage(res, {
-      authState: {
-        email: req.session.user.email,
-        token: req.session.user.token,
-        first_name: req.session.user.first_name,
-        last_name: req.session.user.last_name,
-        isAuthenticated: true,
-        isAdmin: req.session.user.isAdmin
-      }
-    }, '', null, 200);
+    //    console.log('/me','req.session.user=',req.session.user);
+    sendMessage(
+      res,
+      {
+        authState: {
+          email: req.session.user.email,
+          token: req.session.user.token,
+          first_name: req.session.user.first_name,
+          last_name: req.session.user.last_name,
+          isAuthenticated: true,
+          isAdmin: req.session.user.isAdmin,
+        },
+      },
+      "",
+      null,
+      200,
+    );
   } else {
-//    console.log('/me','no req.session.user');
-    sendMessage(res, {
-      authState: {
-        isAuthenticated: false,
-        isAdmin: false
-      }
-    }, '', null, 200);
+    //    console.log('/me','no req.session.user');
+    sendMessage(
+      res,
+      {
+        authState: {
+          isAuthenticated: false,
+          isAdmin: false,
+        },
+      },
+      "",
+      null,
+      200,
+    );
   }
 });
 
 //==================================================================================================
 // LOGOUT
-app.post('/api/v1/logout', (req, res) => {
-//  console.log('/logout');
-  req.session.destroy(() => sendMessage(res,'','',null,200));
+app.post("/api/v1/logout", (req, res) => {
+  //  console.log('/logout');
+  req.session.destroy(() => sendMessage(res, "", "", null, 200));
 });
 
 //==================================================================================================
 // PASSWORD RESET REQUEST
-app.post('/api/v1/reset-password', async (req, res) => {
+app.post("/api/v1/reset-password", async (req, res) => {
   const { email } = req.body;
-//  console.log('/api/v1/reset-password','email=',email);
+  //  console.log('/api/v1/reset-password','email=',email);
 
   if (!isValidEmail(email)) {
-    sendMessage(res, 'Invalid email address format.', 'error', 'email', 400);
+    sendMessage(res, "Invalid email address format.", "error", "email", 400);
     return;
   }
 
   try {
     // Does user exist?
-    const [rows] = await db.execute('SELECT * FROM user WHERE email = ?', [email]);
+    const [rows] = await db.execute("SELECT * FROM user WHERE email = ?", [
+      email,
+    ]);
     if (!rows.length) {
-      sendMessage(res, 'Unknown email or password, or inactive account.', 'error', null, 401);
+      sendMessage(
+        res,
+        "Unknown email or password, or inactive account.",
+        "error",
+        null,
+        401,
+      );
       return;
     }
 
     const user = rows[0];
-//    console.log('/api/v1/reset-password','user=',user);
+    //    console.log('/api/v1/reset-password','user=',user);
     const resetToken = generateToken();
     const local = new Date(Date.now() + 60 * 60 * 1000); // UTC + 1 hour
-    const expiresAt = new Date(local.getTime() + local.getTimezoneOffset() * 60000); // Fudge
-//  console.log('/api/v1/reset-password','expiresAt=',expiresAt);
+    const expiresAt = new Date(
+      local.getTime() + local.getTimezoneOffset() * 60000,
+    ); // Fudge
+    //  console.log('/api/v1/reset-password','expiresAt=',expiresAt);
 
     // Create a reset token
-    await db.execute('INSERT INTO token (token, email, type, expires_at) VALUES (?, ?, ?, ?)', [resetToken, email, 'reset', expiresAt]);
+    await db.execute(
+      "INSERT INTO token (token, email, type, expires_at) VALUES (?, ?, ?, ?)",
+      [resetToken, email, "reset", expiresAt],
+    );
 
     // Send reset email
     try {
       await sendResetEmail(email, user.first_name, user.last_name, resetToken);
-      sendMessage(res, 'Reset password email sent.', 'info', null, 200);
+      sendMessage(res, "Reset password email sent.", "info", null, 200);
     } catch (err) {
-      sendMessage(res, err.response, 'error', null, 500);
+      sendMessage(res, err.response, "error", null, 500);
     }
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // CHANGE PASSWORD
-app.patch('/api/v1/change-password', async (req, res) => {
+app.patch("/api/v1/change-password", async (req, res) => {
   const { token, email, password } = req.body;
-//  console.log('/api/v1/change-password','token=',token,'email=',email,'password=',password);
+  //  console.log('/api/v1/change-password','token=',token,'email=',email,'password=',password);
 
   try {
     // Does a matching reset token exist
-    const [rows] = await db.execute('SELECT email FROM token WHERE email = ? AND token = ? AND type = ? AND expires_at > NOW()', [email, token, 'reset']);
+    const [rows] = await db.execute(
+      "SELECT email FROM token WHERE email = ? AND token = ? AND type = ? AND expires_at > NOW()",
+      [email, token, "reset"],
+    );
     if (!rows.length) {
-      sendMessage(res, 'No outstanding password change exists or has expired.', 'error', null, 401);
+      sendMessage(
+        res,
+        "No outstanding password change exists or has expired.",
+        "error",
+        null,
+        401,
+      );
       return;
     }
 
     if (!isValidPassword(password)) {
-      sendMessage(res, 'Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.', 'error', null, 400);
+      sendMessage(
+        res,
+        "Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.",
+        "error",
+        null,
+        400,
+      );
       return;
     }
 
     // Update the password
     const db_email = rows[0].email;
     const hashed = await hashPassword(password);
-    await db.execute('UPDATE user SET password = ? WHERE email = ?', [hashed, db_email]);
-    await db.execute('DELETE FROM token WHERE token = ?', [token]);
-    sendMessage(res, 'Password changed successfully.', 'info', null, 200);
+    await db.execute("UPDATE user SET password = ? WHERE email = ?", [
+      hashed,
+      db_email,
+    ]);
+    await db.execute("DELETE FROM token WHERE token = ?", [token]);
+    sendMessage(res, "Password changed successfully.", "info", null, 200);
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //==================================================================================================
 // Cleanup Expired Tokens
-app.delete('/api/v1/cleanup-expired-tokens', async (req, res) => {
-//  console.log('/api/v1/cleanup-expired-tokens');
+app.delete("/api/v1/cleanup-expired-tokens", async (req, res) => {
+  //  console.log('/api/v1/cleanup-expired-tokens');
   try {
-    const [rows] = await db.query('DELETE FROM token WHERE expires_at < NOW()');
-//    console.log('/api/v1/cleanup-expired-tokens','rows=',rows);
+    const [rows] = await db.query("DELETE FROM token WHERE expires_at < NOW()");
+    //    console.log('/api/v1/cleanup-expired-tokens','rows=',rows);
 
     if (!rows.affectedRows) {
-      sendMessage(res, 'No expired tokens cleaned up.', 'info', null, 200); // Nothing deleted then no message
+      sendMessage(res, "No expired tokens cleaned up.", "info", null, 200); // Nothing deleted then no message
     } else {
       const delete_count = rows.affectedRows;
-//      console.log('/api/v1/cleanup-expired-tokens','rows=',delete_count);
-      sendMessage(res, `${delete_count} expired token(s) cleaned up successfully.`, 'info', null, 200);
+      //      console.log('/api/v1/cleanup-expired-tokens','rows=',delete_count);
+      sendMessage(
+        res,
+        `${delete_count} expired token(s) cleaned up successfully.`,
+        "info",
+        null,
+        200,
+      );
     }
   } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
+    sendMessage(res, err, "error", null, 500);
   }
 });
 
 //====================================================================================================================
 // Admin User Search
-app.get('/api/v1/users', authenticationRequired, adminRequired, async (req, res) => {
-  const { email, firstName, lastName, role, status } = req.query;
-  console.log('/api/v1/users','email=',email,'firstName=',firstName,'lastName=',lastName,'role=',role,'status=',status);
-  const conditions = [];
-  const params = [];
-  if (email) {
-    conditions.push('email LIKE ?');
-    params.push(`%${email}%`);
-  }
-  if (firstName) {
-    conditions.push('first_name LIKE ?');
-    params.push(`%${firstName}%`);
-  }
-  if (lastName) {
-    conditions.push('last_name LIKE ?');
-    params.push(`%${lastName}%`);
-  }
-  if (role) {
-    conditions.push('role LIKE ?');
-    params.push(`${role}`);
-  }
-  if (status) {
-    conditions.push('status LIKE ?');
-    params.push(`${status}`);
-  }
-
-  const where = conditions.length ? 'WHERE ' + conditions.join(' AND ') : '';
-  try {
-    const [rows] = await db.execute(
-      `SELECT id, email, first_name, last_name, role, status, created_at, last_login_at FROM user ${where}`,
-      params
+app.get(
+  "/api/v1/users",
+  authenticationRequired,
+  adminRequired,
+  async (req, res) => {
+    const { email, firstName, lastName, role, status } = req.query;
+    console.log(
+      "/api/v1/users",
+      "email=",
+      email,
+      "firstName=",
+      firstName,
+      "lastName=",
+      lastName,
+      "role=",
+      role,
+      "status=",
+      status,
     );
-    sendMessage(res, rows, '', null, 200);
-  } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
-  }
-});
+    const conditions = [];
+    const params = [];
+    if (email) {
+      conditions.push("email LIKE ?");
+      params.push(`%${email}%`);
+    }
+    if (firstName) {
+      conditions.push("first_name LIKE ?");
+      params.push(`%${firstName}%`);
+    }
+    if (lastName) {
+      conditions.push("last_name LIKE ?");
+      params.push(`%${lastName}%`);
+    }
+    if (role) {
+      conditions.push("role LIKE ?");
+      params.push(`${role}`);
+    }
+    if (status) {
+      conditions.push("status LIKE ?");
+      params.push(`${status}`);
+    }
+
+    const where = conditions.length ? "WHERE " + conditions.join(" AND ") : "";
+    try {
+      const [rows] = await db.execute(
+        `SELECT id, email, first_name, last_name, role, status, created_at, last_login_at FROM user ${where}`,
+        params,
+      );
+      sendMessage(res, rows, "", null, 200);
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
+    }
+  },
+);
+
+// =============================================================================
+// Admin Create User
+app.post(
+  "/api/v1/users",
+  authenticationRequired,
+  adminRequired,
+  async (req, res) => {
+    const { email, password, first_name, last_name, role, status } = req.body;
+    try {
+      if (!isValidEmail(email)) {
+        sendMessage(
+          res,
+          "Invalid email address format.",
+          "error",
+          "email",
+          400,
+        );
+        return;
+      }
+      if (!isValidPassword(password)) {
+        sendMessage(
+          res,
+          "Password must be at least 8 characters long and include at least one lowercase letter, one uppercase letter, and one number.",
+          "error",
+          "password",
+          400,
+        );
+        return;
+      }
+      const [rows] = await db.execute("SELECT id FROM user WHERE email = ?", [
+        email,
+      ]);
+      if (rows.length) {
+        sendMessage(res, "Duplicate email.", "error", null, 409);
+        return;
+      }
+      const hashed = await hashPassword(password);
+      const [result] = await db.execute(
+        "INSERT INTO user (email, password, first_name, last_name, role, status) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+          email,
+          hashed,
+          first_name,
+          last_name,
+          role || "user",
+          status || "active",
+        ],
+      );
+      sendMessage(res, { id: result.insertId }, "", null, 201);
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
+    }
+  },
+);
+
+// =============================================================================
+// Admin Update User
+app.put(
+  "/api/v1/users/:id",
+  authenticationRequired,
+  adminRequired,
+  async (req, res) => {
+    const { id } = req.params;
+    const { email, first_name, last_name, role, status } = req.body;
+    try {
+      const fields = [];
+      const params = [];
+      if (email) {
+        if (!isValidEmail(email)) {
+          sendMessage(
+            res,
+            "Invalid email address format.",
+            "error",
+            "email",
+            400,
+          );
+          return;
+        }
+        fields.push("email = ?");
+        params.push(email);
+      }
+      if (first_name !== undefined) {
+        fields.push("first_name = ?");
+        params.push(first_name);
+      }
+      if (last_name !== undefined) {
+        fields.push("last_name = ?");
+        params.push(last_name);
+      }
+      if (role) {
+        fields.push("role = ?");
+        params.push(role);
+      }
+      if (status) {
+        fields.push("status = ?");
+        params.push(status);
+      }
+      if (!fields.length) {
+        sendMessage(res, "No fields provided.", "error", null, 400);
+        return;
+      }
+      params.push(id);
+      const [rows] = await db.execute(
+        `UPDATE user SET ${fields.join(", ")} WHERE id = ?`,
+        params,
+      );
+      if (rows.affectedRows === 0) {
+        sendMessage(res, "", "", null, 404);
+      } else {
+        sendMessage(res, {}, "", null, 200);
+      }
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
+    }
+  },
+);
 
 //====================================================================================================================
 // Admin Delete User
-app.delete('/api/v1/users/:id', authenticationRequired, adminRequired, async (req, res) => {
-  const { id } = req.params;
-  console.log('/api/v1/users','id=',id);
-  try {
-    const [rows] = await db.execute('DELETE FROM user WHERE id = ?', [id]);
-    if (rows.affectedRows === 0) {
-      sendMessage(res, '', '', null, 404);
-    } else {
-      sendMessage(res, {}, '', null, 200);
+app.delete(
+  "/api/v1/users/:id",
+  authenticationRequired,
+  adminRequired,
+  async (req, res) => {
+    const { id } = req.params;
+    console.log("/api/v1/users", "id=", id);
+    try {
+      const [rows] = await db.execute("DELETE FROM user WHERE id = ?", [id]);
+      if (rows.affectedRows === 0) {
+        sendMessage(res, "", "", null, 404);
+      } else {
+        sendMessage(res, {}, "", null, 200);
+      }
+    } catch (err) {
+      sendMessage(res, err, "error", null, 500);
     }
-  } catch (err) {
-    sendMessage(res, err, 'error', null, 500);
-  }
-});
+  },
+);
 
 //==================================================================================================
-if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
-//  console.log('process.env.NODE_ENV == production or staging', 'process.env.NODE_ENV=', process.env.NODE_ENV);
+if (
+  process.env.NODE_ENV === "production" ||
+  process.env.NODE_ENV === "staging"
+) {
+  //  console.log('process.env.NODE_ENV == production or staging', 'process.env.NODE_ENV=', process.env.NODE_ENV);
   // If it’s not https already, redirect the same url on https.
   app.use((req, res, next) => {
-    if (req.header('x-forwarded-proto') !== 'https') {
-//      console.log('SERVER: In USE Redirect PATH=', path.join(__dirname, 'client/build', 'index.html'));
-      res.redirect(`https://${req.header('host')}${req.url}`);
+    if (req.header("x-forwarded-proto") !== "https") {
+      //      console.log('SERVER: In USE Redirect PATH=', path.join(__dirname, 'client/build', 'index.html'));
+      res.redirect(`https://${req.header("host")}${req.url}`);
     } else {
-//      console.log('SERVER: In USE next');
+      //      console.log('SERVER: In USE next');
       next();
     }
-  })
+  });
   // Serve any static files
-  app.use(
-    express.static(path.join(__dirname, 'client/build'))
-  );
+  app.use(express.static(path.join(__dirname, "client/build")));
   // Handle React routing, return all requests to React app
-  app.get('*', function(req, res, next) {
-//    console.log('SERVER: In GET * PATH=', path.join(__dirname, 'client/build', 'index.html'));
-    res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
+  app.get("*", function (req, res, next) {
+    //    console.log('SERVER: In GET * PATH=', path.join(__dirname, 'client/build', 'index.html'));
+    res.sendFile(path.join(__dirname, "client/build", "index.html"));
   });
 } else {
-//  console.log('process.env.NODE_ENV != production or staging', 'process.env.NODE_ENV=', process.env.NODE_ENV);
+  //  console.log('process.env.NODE_ENV != production or staging', 'process.env.NODE_ENV=', process.env.NODE_ENV);
 }
 
 const port = process.env.PORT || 5000;
-if (!module.parent) { // If not in a testcase then start listening
+if (!module.parent) {
+  // If not in a testcase then start listening
   app.listen(port, () => {
-    console.log('SERVER:', 'PUBLIC_URL=', process.env.PUBLIC_URL, 'NODE_ENV=', process.env.NODE_ENV, 'starting on port=', port, 'node version=', process.version);
+    console.log(
+      "SERVER:",
+      "PUBLIC_URL=",
+      process.env.PUBLIC_URL,
+      "NODE_ENV=",
+      process.env.NODE_ENV,
+      "starting on port=",
+      port,
+      "node version=",
+      process.version,
+    );
   });
 }
 

--- a/test/api_users_search_test.js
+++ b/test/api_users_search_test.js
@@ -1,22 +1,24 @@
-require('dotenv').config();
+require("dotenv").config();
 
-process.env.NODE_ENV = 'test';
+process.env.NODE_ENV = "test";
 
-const mysql = require('mysql');
-let chai = require('chai');
-let chaiHttp = require('chai-http');
-let server = require('../server');
+const mysql = require("mysql");
+let chai = require("chai");
+let chaiHttp = require("chai-http");
+let server = require("../server");
 let should = chai.should();
 let userId;
+let newUserId;
 
 chai.use(chaiHttp);
 
-describe('Admin User Search', () => {
+describe("Admin User Search", () => {
   before((done) => {
     var connection = mysql.createConnection(process.env.JAWSDB_TEST_URL);
     connection.connect();
-    const stmt = "INSERT INTO user (email, first_name, last_name, role, token, status) VALUES ('search@example.com','First','Last','admin','ADMINTOKEN','active')";
-    connection.query(stmt, function(err, results) {
+    const stmt =
+      "INSERT INTO user (email, first_name, last_name, role, token, status) VALUES ('search@example.com','First','Last','admin','ADMINTOKEN','active')";
+    connection.query(stmt, function (err, results) {
       if (!err) userId = results.insertId;
       connection.end();
       done(err);
@@ -26,40 +28,83 @@ describe('Admin User Search', () => {
   after((done) => {
     var connection = mysql.createConnection(process.env.JAWSDB_TEST_URL);
     connection.connect();
-    connection.query('DELETE FROM user WHERE id = ?', [userId], function(err) {
+    connection.query("DELETE FROM user WHERE id = ?", [userId], function (err) {
       connection.end();
       done(err);
     });
   });
 
-  it('should fail without auth', (done) => {
+  it("should fail without auth", (done) => {
     chai
       .request(server)
-      .get('/api/v1/users')
+      .get("/api/v1/users")
       .end((err, res) => {
         res.should.have.status(401);
         done(err);
       });
   });
 
-  it('should get user list by email', (done) => {
+  it("should create user", (done) => {
     chai
       .request(server)
-      .get('/api/v1/users?email=search@example.com')
-      .set('Authorization', 'Bearer ADMINTOKEN')
+      .post("/api/v1/users")
+      .set("Authorization", "Bearer ADMINTOKEN")
+      .send({
+        email: "newuser@example.com",
+        password: "Valid123",
+        first_name: "New",
+        last_name: "User",
+        role: "user",
+        status: "active",
+      })
+      .end((err, res) => {
+        res.should.have.status(201);
+        newUserId = res.body.id;
+        done(err);
+      });
+  });
+
+  it("should get user list by email", (done) => {
+    chai
+      .request(server)
+      .get("/api/v1/users?email=search@example.com")
+      .set("Authorization", "Bearer ADMINTOKEN")
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.a('array');
+        res.body.should.be.a("array");
         res.body.length.should.be.eql(1);
         done(err);
       });
   });
 
-  it('should delete user by id', (done) => {
+  it("should update user role", (done) => {
+    chai
+      .request(server)
+      .put(`/api/v1/users/${newUserId}`)
+      .set("Authorization", "Bearer ADMINTOKEN")
+      .send({ role: "admin" })
+      .end((err, res) => {
+        res.should.have.status(200);
+        done(err);
+      });
+  });
+
+  it("should delete user by id", (done) => {
     chai
       .request(server)
       .delete(`/api/v1/users/${userId}`)
-      .set('Authorization', 'Bearer ADMINTOKEN')
+      .set("Authorization", "Bearer ADMINTOKEN")
+      .end((err, res) => {
+        res.should.have.status(200);
+        done(err);
+      });
+  });
+
+  it("should delete new user", (done) => {
+    chai
+      .request(server)
+      .delete(`/api/v1/users/${newUserId}`)
+      .set("Authorization", "Bearer ADMINTOKEN")
       .end((err, res) => {
         res.should.have.status(200);
         done(err);


### PR DESCRIPTION
## Summary
- add backend endpoints for admin user creation and update
- add `AdminUserModal` reusable for create/edit
- enhance AdminUserSearchPage with New User button and edit button
- test admin user endpoints

## Testing
- `npm test` *(fails: connect ENETUNREACH)*
- `cd client && npm test -- -w 1` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686d215fca8083309e2a87e787951e64