### PR TITLE
Add token search and editing

### DIFF
--- a/client/src/menus/Admin/AdminUserManagerPage.js
+++ b/client/src/menus/Admin/AdminUserManagerPage.js
@@ -12,6 +12,7 @@ export default function AdminUserManagerPage() {
   const [lastName, setLastName] = useState('');
   const [role, setRole] = useState('');
   const [status, setStatus] = useState('');
+  const [token, setToken] = useState('');
   const [createStartDate, setCreateStartDate] = useState('');
   const [createEndDate, setCreateEndDate] = useState('');
   const [loginStartDate, setLoginStartDate] = useState('');
@@ -48,11 +49,11 @@ export default function AdminUserManagerPage() {
         headers: {
           Authorization: 'Bearer ' + authState.token
         },
-        params: { email, firstName, lastName, role, status, createStartDate, createEndDate, loginStartDate, loginEndDate },
+        params: { email, firstName, lastName, role, status, token, createStartDate, createEndDate, loginStartDate, loginEndDate },
       });
       setError(res.data.error);
       setResults(res.data);
-      logUsage('event', 'AdminUserManagerPage', { event_label: 'search email:' + email + ' firstName:' + firstName + ' lastName:' + lastName + ' role:' + role + ' status:' + status + ' createStartDate:' + createStartDate + ' createEndDate:' + createEndDate + ' loginStartDate:' + loginStartDate + ' loginEndDate:' + loginEndDate });
+      logUsage('event', 'AdminUserManagerPage', { event_label: 'search email:' + email + ' firstName:' + firstName + ' lastName:' + lastName + ' role:' + role + ' status:' + status + ' token:' + token + ' createStartDate:' + createStartDate + ' createEndDate:' + createEndDate + ' loginStartDate:' + loginStartDate + ' loginEndDate:' + loginEndDate });
     } catch (err) {
       setError(err.response?.data?.error || err.message);
       setResults([]);
@@ -126,6 +127,17 @@ export default function AdminUserManagerPage() {
                       <Form.Control
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
+                      />
+                    </Form.Group>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <Form.Group controlId="searchToken">
+                      <Form.Label>Token</Form.Label>
+                      <Form.Control
+                        value={token}
+                        onChange={(e) => setToken(e.target.value)}
                       />
                     </Form.Group>
                   </td>
@@ -233,6 +245,7 @@ export default function AdminUserManagerPage() {
                 setLastName('');
                 setRole('');
                 setStatus('');
+                setToken('');
                 setCreateStartDate('');
                 setCreateEndDate('');
                 setLoginStartDate('');
@@ -263,6 +276,9 @@ export default function AdminUserManagerPage() {
                   <th onClick={() => handleSort('role')} style={{ cursor: 'pointer' }}>
                     Role{sortIcon('role')}
                   </th>
+                  <th onClick={() => handleSort('token')} style={{ cursor: 'pointer' }}>
+                    Token{sortIcon('token')}
+                  </th>
                   <th onClick={() => handleSort('status')} style={{ cursor: 'pointer' }}>
                     Status{sortIcon('status')}
                   </th>
@@ -287,6 +303,7 @@ export default function AdminUserManagerPage() {
                     <td>{u.first_name}</td>
                     <td>{u.last_name}</td>
                     <td>{u.role}</td>
+                    <td>{u.token}</td>
                     <td>{u.status}</td>
                     <td>{u.created_at}</td>
                     <td>{u.last_login_at}</td>

--- a/client/src/menus/Admin/AdminUserModal.js
+++ b/client/src/menus/Admin/AdminUserModal.js
@@ -13,6 +13,7 @@ export default function AdminUserModal({ show, onHide, user, onSaved }) {
   const [lastName, setLastName] = useState("");
   const [role, setRole] = useState("user");
   const [status, setStatus] = useState("active");
+  const [token, setToken] = useState("");
   const [error, setError] = useState(null);
   const { authState } = useAuth();
 
@@ -32,6 +33,7 @@ export default function AdminUserModal({ show, onHide, user, onSaved }) {
       setLastName(user.last_name || "");
       setRole(user.role || "user");
       setStatus(user.status || "active");
+      setToken(user.token || "");
     } else {
       setEmail("");
       setPassword("");
@@ -39,6 +41,7 @@ export default function AdminUserModal({ show, onHide, user, onSaved }) {
       setLastName("");
       setRole("user");
       setStatus("active");
+      setToken("");
     }
   }, [user, show]);
 
@@ -47,9 +50,9 @@ export default function AdminUserModal({ show, onHide, user, onSaved }) {
     setError(null);
     try {
       if (isEdit) {
-        await axios.put(`/api/v1/users/${user.id}`, { email, first_name: firstName, last_name: lastName, role, status }, { headers: { Authorization: "Bearer " + authState.token } });
+        await axios.put(`/api/v1/users/${user.id}`, { email, first_name: firstName, last_name: lastName, role, status, token }, { headers: { Authorization: "Bearer " + authState.token } });
       } else {
-        await axios.post("/api/v1/users", { email, password, first_name: firstName, last_name: lastName, role, status }, { headers: { Authorization: "Bearer " + authState.token } });
+        await axios.post("/api/v1/users", { email, password, first_name: firstName, last_name: lastName, role, status, token }, { headers: { Authorization: "Bearer " + authState.token } });
       }
       logUsage("event", "AdminUserModal", {
         event_label: isEdit ? "update" : "create",
@@ -134,6 +137,18 @@ export default function AdminUserModal({ show, onHide, user, onSaved }) {
                     </Form.Select>
                   </Form.Group>
                 </td>
+              </tr>
+              <tr>
+                <td>
+                  <Form.Group controlId="userToken">
+                    <Form.Label>Token</Form.Label>
+                    <Form.Control
+                      value={token}
+                      onChange={(e) => setToken(e.target.value)}
+                    />
+                  </Form.Group>
+                </td>
+                <td></td>
               </tr>
             </tbody>
           </Table>

--- a/test/api_users_search_test.js
+++ b/test/api_users_search_test.js
@@ -56,6 +56,7 @@ describe("Admin User Manager", () => {
         last_name: "User",
         role: "user",
         status: "active",
+        token: "NEWTOKEN",
       })
       .end((err, res) => {
         res.should.have.status(201);
@@ -73,6 +74,7 @@ describe("Admin User Manager", () => {
         res.should.have.status(200);
         res.body.should.be.a("array");
         res.body.length.should.be.eql(1);
+        res.body[0].should.have.property("token");
         done(err);
       });
   });
@@ -85,6 +87,31 @@ describe("Admin User Manager", () => {
       .send({ role: "admin" })
       .end((err, res) => {
         res.should.have.status(200);
+        done(err);
+      });
+  });
+
+  it("should update user token", (done) => {
+    chai
+      .request(server)
+      .put(`/api/v1/users/${newUserId}`)
+      .set("Authorization", "Bearer ADMINTOKEN")
+      .send({ token: "UPDATEDTOKEN" })
+      .end((err, res) => {
+        res.should.have.status(200);
+        done(err);
+      });
+  });
+
+  it("should get user by token", (done) => {
+    chai
+      .request(server)
+      .get("/api/v1/users?token=UPDATEDTOKEN")
+      .set("Authorization", "Bearer ADMINTOKEN")
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a("array");
+        res.body.length.should.be.eql(1);
         done(err);
       });
   });


### PR DESCRIPTION
## Summary
- search by user token in admin page
- display token in user manager list
- allow editing/creating token via admin modal
- update user API endpoints to support token field
- test token create, update and search

## Testing
- `npm test` *(fails: connect ENETUNREACH 52.202.225.103:3306)*
- `cd client && npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_686f1bb20c848330aa0a1496c9ca7be6